### PR TITLE
Add card variants for SV sets

### DIFF
--- a/cards/en/sv1.json
+++ b/cards/en/sv1.json
@@ -49,7 +49,11 @@
       "small": "https://images.pokemontcg.io/sv1/1.png",
       "large": "https://images.pokemontcg.io/sv1/1_hires.png"
     },
-    "flavorText": "It spits out a fluid that it uses to glue tree bark to its body. The fluid hardens when it touches air."
+    "flavorText": "It spits out a fluid that it uses to glue tree bark to its body. The fluid hardens when it touches air.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-2",
@@ -112,7 +116,11 @@
       "small": "https://images.pokemontcg.io/sv1/2.png",
       "large": "https://images.pokemontcg.io/sv1/2_hires.png"
     },
-    "flavorText": "With its herculean powers, it can easily throw around an object that is 100 times its own weight."
+    "flavorText": "With its herculean powers, it can easily throw around an object that is 100 times its own weight.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-3",
@@ -162,7 +170,11 @@
       "small": "https://images.pokemontcg.io/sv1/3.png",
       "large": "https://images.pokemontcg.io/sv1/3_hires.png"
     },
-    "flavorText": "It prefers damp places. By day it remains still in the forest shade. It releases toxic powder from its head."
+    "flavorText": "It prefers damp places. By day it remains still in the forest shade. It releases toxic powder from its head.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-4",
@@ -213,7 +225,11 @@
       "small": "https://images.pokemontcg.io/sv1/4.png",
       "large": "https://images.pokemontcg.io/sv1/4_hires.png"
     },
-    "flavorText": "It scatters poisonous spores and throws powerful punches while its foe is hampered by inhaled spores."
+    "flavorText": "It scatters poisonous spores and throws powerful punches while its foe is hampered by inhaled spores.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-5",
@@ -271,7 +287,11 @@
       "small": "https://images.pokemontcg.io/sv1/5.png",
       "large": "https://images.pokemontcg.io/sv1/5_hires.png"
     },
-    "flavorText": "It prefers harsh environments, such as deserts. It can survive for 30 days on water stored in its body."
+    "flavorText": "It prefers harsh environments, such as deserts. It can survive for 30 days on water stored in its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-6",
@@ -332,7 +352,11 @@
       "small": "https://images.pokemontcg.io/sv1/6.png",
       "large": "https://images.pokemontcg.io/sv1/6_hires.png"
     },
-    "flavorText": "Packs of them follow travelers through the desert until the travelers can no longer move."
+    "flavorText": "Packs of them follow travelers through the desert until the travelers can no longer move.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-7",
@@ -392,7 +416,11 @@
       "small": "https://images.pokemontcg.io/sv1/7.png",
       "large": "https://images.pokemontcg.io/sv1/7_hires.png"
     },
-    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year."
+    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-8",
@@ -450,7 +478,11 @@
       "small": "https://images.pokemontcg.io/sv1/8.png",
       "large": "https://images.pokemontcg.io/sv1/8_hires.png"
     },
-    "flavorText": "This Pokémon scatters poisonous powder to repel enemies. It will eat different plants depending on where it lives."
+    "flavorText": "This Pokémon scatters poisonous powder to repel enemies. It will eat different plants depending on where it lives.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-9",
@@ -511,7 +543,11 @@
       "small": "https://images.pokemontcg.io/sv1/9.png",
       "large": "https://images.pokemontcg.io/sv1/9_hires.png"
     },
-    "flavorText": "Spewpa doesn't live in a fixed location. It roams where it pleases across the fields and mountains, building up the energy it needs to evolve."
+    "flavorText": "Spewpa doesn't live in a fixed location. It roams where it pleases across the fields and mountains, building up the energy it needs to evolve.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-10",
@@ -572,7 +608,11 @@
       "small": "https://images.pokemontcg.io/sv1/10.png",
       "large": "https://images.pokemontcg.io/sv1/10_hires.png"
     },
-    "flavorText": "This Pokémon was born in a land where flowers bloom. It scatters colorful, toxic scales from its wings during battle."
+    "flavorText": "This Pokémon was born in a land where flowers bloom. It scatters colorful, toxic scales from its wings during battle.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-11",
@@ -632,7 +672,11 @@
       "small": "https://images.pokemontcg.io/sv1/11.png",
       "large": "https://images.pokemontcg.io/sv1/11_hires.png"
     },
-    "flavorText": "Until recently, people living in the mountains would ride on the back of these Pokémon to traverse the mountain paths."
+    "flavorText": "Until recently, people living in the mountains would ride on the back of these Pokémon to traverse the mountain paths.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-12",
@@ -696,7 +740,11 @@
       "small": "https://images.pokemontcg.io/sv1/12.png",
       "large": "https://images.pokemontcg.io/sv1/12_hires.png"
     },
-    "flavorText": "It can sense the feelings of others by touching them with its horns. This species has assisted people with their work since 5,000 years ago."
+    "flavorText": "It can sense the feelings of others by touching them with its horns. This species has assisted people with their work since 5,000 years ago.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-13",
@@ -756,7 +804,12 @@
       "small": "https://images.pokemontcg.io/sv1/13.png",
       "large": "https://images.pokemontcg.io/sv1/13_hires.png"
     },
-    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
+    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv1-14",
@@ -817,7 +870,11 @@
       "small": "https://images.pokemontcg.io/sv1/14.png",
       "large": "https://images.pokemontcg.io/sv1/14_hires.png"
     },
-    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents."
+    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-15",
@@ -878,7 +935,12 @@
       "small": "https://images.pokemontcg.io/sv1/15.png",
       "large": "https://images.pokemontcg.io/sv1/15_hires.png"
     },
-    "flavorText": "This Pokémon uses the reflective fur lining its cape to camouflage the stem of its flower, creating the illusion that the flower is floating."
+    "flavorText": "This Pokémon uses the reflective fur lining its cape to camouflage the stem of its flower, creating the illusion that the flower is floating.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv1-16",
@@ -937,7 +999,11 @@
       "small": "https://images.pokemontcg.io/sv1/16.png",
       "large": "https://images.pokemontcg.io/sv1/16_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-17",
@@ -988,7 +1054,11 @@
       "small": "https://images.pokemontcg.io/sv1/17.png",
       "large": "https://images.pokemontcg.io/sv1/17_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-18",
@@ -1039,7 +1109,11 @@
       "small": "https://images.pokemontcg.io/sv1/18.png",
       "large": "https://images.pokemontcg.io/sv1/18_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-19",
@@ -1103,7 +1177,11 @@
       "small": "https://images.pokemontcg.io/sv1/19.png",
       "large": "https://images.pokemontcg.io/sv1/19_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-20",
@@ -1154,7 +1232,11 @@
       "small": "https://images.pokemontcg.io/sv1/20.png",
       "large": "https://images.pokemontcg.io/sv1/20_hires.png"
     },
-    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch."
+    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-21",
@@ -1214,7 +1296,11 @@
       "small": "https://images.pokemontcg.io/sv1/21.png",
       "large": "https://images.pokemontcg.io/sv1/21_hires.png"
     },
-    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch."
+    "flavorText": "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-22",
@@ -1275,7 +1361,11 @@
       "small": "https://images.pokemontcg.io/sv1/22.png",
       "large": "https://images.pokemontcg.io/sv1/22_hires.png"
     },
-    "flavorText": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone."
+    "flavorText": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-23",
@@ -1336,7 +1426,13 @@
       "small": "https://images.pokemontcg.io/sv1/23.png",
       "large": "https://images.pokemontcg.io/sv1/23_hires.png"
     },
-    "flavorText": "This calm Pokémon is very compassionate. It will share its delicious, nutrient-rich oil with weakened Pokémon."
+    "flavorText": "This calm Pokémon is very compassionate. It will share its delicious, nutrient-rich oil with weakened Pokémon.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Vertical Line Holo"
+    ]
   },
   {
     "id": "sv1-24",
@@ -1386,7 +1482,11 @@
       "small": "https://images.pokemontcg.io/sv1/24.png",
       "large": "https://images.pokemontcg.io/sv1/24_hires.png"
     },
-    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph."
+    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-25",
@@ -1447,7 +1547,11 @@
       "small": "https://images.pokemontcg.io/sv1/25.png",
       "large": "https://images.pokemontcg.io/sv1/25_hires.png"
     },
-    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph."
+    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-26",
@@ -1510,7 +1614,11 @@
       "small": "https://images.pokemontcg.io/sv1/26.png",
       "large": "https://images.pokemontcg.io/sv1/26_hires.png"
     },
-    "flavorText": "It coils its 10 tentacles around prey and sucks out their nutrients, causing the prey pain. The folds along the rim of its head are a popular delicacy."
+    "flavorText": "It coils its 10 tentacles around prey and sucks out their nutrients, causing the prey pain. The folds along the rim of its head are a popular delicacy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-27",
@@ -1560,7 +1668,11 @@
       "small": "https://images.pokemontcg.io/sv1/27.png",
       "large": "https://images.pokemontcg.io/sv1/27_hires.png"
     },
-    "flavorText": "Traditional Paldean dishes can be extremely spicy because they include the shed front teeth of Capsakid among their ingredients."
+    "flavorText": "Traditional Paldean dishes can be extremely spicy because they include the shed front teeth of Capsakid among their ingredients.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-28",
@@ -1621,7 +1733,11 @@
       "small": "https://images.pokemontcg.io/sv1/28.png",
       "large": "https://images.pokemontcg.io/sv1/28_hires.png"
     },
-    "flavorText": "Traditional Paldean dishes can be extremely spicy because they include the shed front teeth of Capsakid among their ingredients."
+    "flavorText": "Traditional Paldean dishes can be extremely spicy because they include the shed front teeth of Capsakid among their ingredients.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-29",
@@ -1683,7 +1799,11 @@
       "small": "https://images.pokemontcg.io/sv1/29.png",
       "large": "https://images.pokemontcg.io/sv1/29_hires.png"
     },
-    "flavorText": "The green head has turned vicious due to the spicy chemicals stimulating its brain. Once it goes on a rampage, there is no stopping it."
+    "flavorText": "The green head has turned vicious due to the spicy chemicals stimulating its brain. Once it goes on a rampage, there is no stopping it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-30",
@@ -1734,7 +1854,11 @@
       "small": "https://images.pokemontcg.io/sv1/30.png",
       "large": "https://images.pokemontcg.io/sv1/30_hires.png"
     },
-    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-31",
@@ -1797,7 +1921,11 @@
       "small": "https://images.pokemontcg.io/sv1/31.png",
       "large": "https://images.pokemontcg.io/sv1/31_hires.png"
     },
-    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-32",
@@ -1868,7 +1996,10 @@
       "small": "https://images.pokemontcg.io/sv1/32.png",
       "large": "https://images.pokemontcg.io/sv1/32_hires.png"
     },
-    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting."
+    "flavorText": "It's very friendly and faithful to people. It will try to repel enemies by barking and biting.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-33",
@@ -1928,7 +2059,11 @@
       "small": "https://images.pokemontcg.io/sv1/33.png",
       "large": "https://images.pokemontcg.io/sv1/33_hires.png"
     },
-    "flavorText": "It uses different kinds of cries for communicating with others of its kind and for pursuing its prey."
+    "flavorText": "It uses different kinds of cries for communicating with others of its kind and for pursuing its prey.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-34",
@@ -1991,7 +2126,12 @@
       "small": "https://images.pokemontcg.io/sv1/34.png",
       "large": "https://images.pokemontcg.io/sv1/34_hires.png"
     },
-    "flavorText": "Upon hearing its eerie howls, other Pokémon get the shivers and head straight back to their nests."
+    "flavorText": "Upon hearing its eerie howls, other Pokémon get the shivers and head straight back to their nests.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-35",
@@ -2055,7 +2195,11 @@
       "small": "https://images.pokemontcg.io/sv1/35.png",
       "large": "https://images.pokemontcg.io/sv1/35_hires.png"
     },
-    "flavorText": "It burns coal inside its shell for energy. It blows out black soot if it is endangered."
+    "flavorText": "It burns coal inside its shell for energy. It blows out black soot if it is endangered.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-36",
@@ -2117,7 +2261,12 @@
       "small": "https://images.pokemontcg.io/sv1/36.png",
       "large": "https://images.pokemontcg.io/sv1/36_hires.png"
     },
-    "flavorText": "Its flame sac is small, so energy is always leaking out. This energy is released from the dent atop Fuecoco's head and flickers to and fro."
+    "flavorText": "Its flame sac is small, so energy is always leaking out. This energy is released from the dent atop Fuecoco's head and flickers to and fro.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv1-37",
@@ -2182,7 +2331,11 @@
       "small": "https://images.pokemontcg.io/sv1/37.png",
       "large": "https://images.pokemontcg.io/sv1/37_hires.png"
     },
-    "flavorText": "The valve in Crocalor's flame sac is closely connected to its vocal cords. This Pokémon utters a guttural cry as it spews flames every which way."
+    "flavorText": "The valve in Crocalor's flame sac is closely connected to its vocal cords. This Pokémon utters a guttural cry as it spews flames every which way.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-38",
@@ -2246,7 +2399,13 @@
       "small": "https://images.pokemontcg.io/sv1/38.png",
       "large": "https://images.pokemontcg.io/sv1/38_hires.png"
     },
-    "flavorText": "Skeledirge's gentle singing soothes the souls of all that hear it. It burns its enemies to a crisp with flames of over 5,400 degrees Fahrenheit."
+    "flavorText": "Skeledirge's gentle singing soothes the souls of all that hear it. It burns its enemies to a crisp with flames of over 5,400 degrees Fahrenheit.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv1-39",
@@ -2296,7 +2455,11 @@
       "small": "https://images.pokemontcg.io/sv1/39.png",
       "large": "https://images.pokemontcg.io/sv1/39_hires.png"
     },
-    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents."
+    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-40",
@@ -2348,7 +2511,11 @@
       "small": "https://images.pokemontcg.io/sv1/40.png",
       "large": "https://images.pokemontcg.io/sv1/40_hires.png"
     },
-    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents."
+    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-41",
@@ -2409,7 +2576,13 @@
       "small": "https://images.pokemontcg.io/sv1/41.png",
       "large": "https://images.pokemontcg.io/sv1/41_hires.png"
     },
-    "flavorText": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal."
+    "flavorText": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon",
+      "Vertical Line Holo"
+    ]
   },
   {
     "id": "sv1-42",
@@ -2470,7 +2643,11 @@
       "small": "https://images.pokemontcg.io/sv1/42.png",
       "large": "https://images.pokemontcg.io/sv1/42_hires.png"
     },
-    "flavorText": "It is always vacantly lost in thought, but no one knows what it is thinking about. It is good at fishing with its tail."
+    "flavorText": "It is always vacantly lost in thought, but no one knows what it is thinking about. It is good at fishing with its tail.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-43",
@@ -2531,7 +2708,12 @@
       "small": "https://images.pokemontcg.io/sv1/43.png",
       "large": "https://images.pokemontcg.io/sv1/43_hires.png"
     },
-    "flavorText": "If the tail-biting Shellder is thrown off in a harsh battle, this Pokémon reverts to being an ordinary Slowpoke."
+    "flavorText": "If the tail-biting Shellder is thrown off in a harsh battle, this Pokémon reverts to being an ordinary Slowpoke.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-44",
@@ -2581,7 +2763,11 @@
       "small": "https://images.pokemontcg.io/sv1/44.png",
       "large": "https://images.pokemontcg.io/sv1/44_hires.png"
     },
-    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet."
+    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-45",
@@ -2656,7 +2842,10 @@
       "small": "https://images.pokemontcg.io/sv1/45.png",
       "large": "https://images.pokemontcg.io/sv1/45_hires.png"
     },
-    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet."
+    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-46",
@@ -2716,7 +2905,11 @@
       "small": "https://images.pokemontcg.io/sv1/46.png",
       "large": "https://images.pokemontcg.io/sv1/46_hires.png"
     },
-    "flavorText": "It spins its two tails like a screw to propel itself through water. The tails also slice clinging seaweed."
+    "flavorText": "It spins its two tails like a screw to propel itself through water. The tails also slice clinging seaweed.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-47",
@@ -2768,7 +2961,11 @@
       "small": "https://images.pokemontcg.io/sv1/47.png",
       "large": "https://images.pokemontcg.io/sv1/47_hires.png"
     },
-    "flavorText": "With its flotation sac inflated, it can carry people on its back. It deflates the sac before it dives."
+    "flavorText": "With its flotation sac inflated, it can carry people on its back. It deflates the sac before it dives.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-48",
@@ -2831,7 +3028,11 @@
       "small": "https://images.pokemontcg.io/sv1/48.png",
       "large": "https://images.pokemontcg.io/sv1/48_hires.png"
     },
-    "flavorText": "It gently holds injured and weak Pokémon in its fins. Its special membrane heals their wounds."
+    "flavorText": "It gently holds injured and weak Pokémon in its fins. Its special membrane heals their wounds.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-49",
@@ -2881,7 +3082,11 @@
       "small": "https://images.pokemontcg.io/sv1/49.png",
       "large": "https://images.pokemontcg.io/sv1/49_hires.png"
     },
-    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes."
+    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-50",
@@ -2945,7 +3150,11 @@
       "small": "https://images.pokemontcg.io/sv1/50.png",
       "large": "https://images.pokemontcg.io/sv1/50_hires.png"
     },
-    "flavorText": "The cannonballs of seawater that Clawitzer launches from its claw are powerful enough to punch through tanker hulls."
+    "flavorText": "The cannonballs of seawater that Clawitzer launches from its claw are powerful enough to punch through tanker hulls.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-51",
@@ -3005,7 +3214,11 @@
       "small": "https://images.pokemontcg.io/sv1/51.png",
       "large": "https://images.pokemontcg.io/sv1/51_hires.png"
     },
-    "flavorText": "It grinds its teeth with great force to stimulate its brain. It fires the psychic energy created by this process from the protuberance on its head."
+    "flavorText": "It grinds its teeth with great force to stimulate its brain. It fires the psychic energy created by this process from the protuberance on its head.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-52",
@@ -3065,7 +3278,12 @@
       "small": "https://images.pokemontcg.io/sv1/52.png",
       "large": "https://images.pokemontcg.io/sv1/52_hires.png"
     },
-    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime."
+    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv1-53",
@@ -3127,7 +3345,11 @@
       "small": "https://images.pokemontcg.io/sv1/53.png",
       "large": "https://images.pokemontcg.io/sv1/53_hires.png"
     },
-    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully."
+    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-54",
@@ -3188,7 +3410,14 @@
       "small": "https://images.pokemontcg.io/sv1/54.png",
       "large": "https://images.pokemontcg.io/sv1/54_hires.png"
     },
-    "flavorText": "A single kick from a Quaquaval can send a truck rolling. This Pokémon uses its powerful legs to perform striking dances from far-off lands."
+    "flavorText": "A single kick from a Quaquaval can send a truck rolling. This Pokémon uses its powerful legs to perform striking dances from far-off lands.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-55",
@@ -3238,7 +3467,11 @@
       "small": "https://images.pokemontcg.io/sv1/55.png",
       "large": "https://images.pokemontcg.io/sv1/55_hires.png"
     },
-    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand."
+    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-56",
@@ -3298,7 +3531,11 @@
       "small": "https://images.pokemontcg.io/sv1/56.png",
       "large": "https://images.pokemontcg.io/sv1/56_hires.png"
     },
-    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand."
+    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-57",
@@ -3361,7 +3598,11 @@
       "small": "https://images.pokemontcg.io/sv1/57.png",
       "large": "https://images.pokemontcg.io/sv1/57_hires.png"
     },
-    "flavorText": "It has a vicious temperament, contrary to what its appearance may suggest. It wraps its long bodies around prey, then drags the prey into its den."
+    "flavorText": "It has a vicious temperament, contrary to what its appearance may suggest. It wraps its long bodies around prey, then drags the prey into its den.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-58",
@@ -3413,7 +3654,11 @@
       "small": "https://images.pokemontcg.io/sv1/58.png",
       "large": "https://images.pokemontcg.io/sv1/58_hires.png"
     },
-    "flavorText": "It lives in frigid regions in pods of five or so individuals. It loves the minerals found in snow and ice."
+    "flavorText": "It lives in frigid regions in pods of five or so individuals. It loves the minerals found in snow and ice.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-59",
@@ -3476,7 +3721,11 @@
       "small": "https://images.pokemontcg.io/sv1/59.png",
       "large": "https://images.pokemontcg.io/sv1/59_hires.png"
     },
-    "flavorText": "It lives in frigid regions in pods of five or so individuals. It loves the minerals found in snow and ice."
+    "flavorText": "It lives in frigid regions in pods of five or so individuals. It loves the minerals found in snow and ice.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-60",
@@ -3541,7 +3790,11 @@
       "small": "https://images.pokemontcg.io/sv1/60.png",
       "large": "https://images.pokemontcg.io/sv1/60_hires.png"
     },
-    "flavorText": "Ice energy builds up in the horn on its upper jaw, causing the horn to reach cryogenic temperatures that freeze its surroundings."
+    "flavorText": "Ice energy builds up in the horn on its upper jaw, causing the horn to reach cryogenic temperatures that freeze its surroundings.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-61",
@@ -3607,7 +3860,15 @@
       "small": "https://images.pokemontcg.io/sv1/61.png",
       "large": "https://images.pokemontcg.io/sv1/61_hires.png"
     },
-    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey."
+    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "Vertical Line Holo"
+    ]
   },
   {
     "id": "sv1-62",
@@ -3666,7 +3927,13 @@
       "small": "https://images.pokemontcg.io/sv1/62.png",
       "large": "https://images.pokemontcg.io/sv1/62_hires.png"
     },
-    "flavorText": "This is a small dragon Pokémon. It lives inside the mouth of Dondozo to protect itself from enemies on the outside."
+    "flavorText": "This is a small dragon Pokémon. It lives inside the mouth of Dondozo to protect itself from enemies on the outside.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-63",
@@ -3725,7 +3992,11 @@
       "small": "https://images.pokemontcg.io/sv1/63.png",
       "large": "https://images.pokemontcg.io/sv1/63_hires.png"
     },
-    "flavorText": "It moves while constantly hovering. It discharges electromagnetic waves and so on from the units at its sides."
+    "flavorText": "It moves while constantly hovering. It discharges electromagnetic waves and so on from the units at its sides.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-64",
@@ -3787,7 +4058,11 @@
       "small": "https://images.pokemontcg.io/sv1/64.png",
       "large": "https://images.pokemontcg.io/sv1/64_hires.png"
     },
-    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up."
+    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-65",
@@ -3854,7 +4129,11 @@
       "small": "https://images.pokemontcg.io/sv1/65.png",
       "large": "https://images.pokemontcg.io/sv1/65_hires.png"
     },
-    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up."
+    "flavorText": "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-66",
@@ -3915,7 +4194,11 @@
       "small": "https://images.pokemontcg.io/sv1/66.png",
       "large": "https://images.pokemontcg.io/sv1/66_hires.png"
     },
-    "flavorText": "Its fleece grows continually. In the summer, the fleece is fully shed, but it grows back in a week."
+    "flavorText": "Its fleece grows continually. In the summer, the fleece is fully shed, but it grows back in a week.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-67",
@@ -3978,7 +4261,11 @@
       "small": "https://images.pokemontcg.io/sv1/67.png",
       "large": "https://images.pokemontcg.io/sv1/67_hires.png"
     },
-    "flavorText": "Because of its rubbery, electricity-resistant skin, it can store lots of electricity in its fur."
+    "flavorText": "Because of its rubbery, electricity-resistant skin, it can store lots of electricity in its fur.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-68",
@@ -4036,7 +4323,11 @@
       "small": "https://images.pokemontcg.io/sv1/68.png",
       "large": "https://images.pokemontcg.io/sv1/68_hires.png"
     },
-    "flavorText": "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity."
+    "flavorText": "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-69",
@@ -4086,7 +4377,11 @@
       "small": "https://images.pokemontcg.io/sv1/69.png",
       "large": "https://images.pokemontcg.io/sv1/69_hires.png"
     },
-    "flavorText": "Research continues on this Pokémon, which could be the power source of a unique motor."
+    "flavorText": "Research continues on this Pokémon, which could be the power source of a unique motor.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-70",
@@ -4145,7 +4440,12 @@
       "small": "https://images.pokemontcg.io/sv1/70.png",
       "large": "https://images.pokemontcg.io/sv1/70_hires.png"
     },
-    "flavorText": "Research continues on this Pokémon, which could be the power source of a unique motor."
+    "flavorText": "Research continues on this Pokémon, which could be the power source of a unique motor.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv1-71",
@@ -4197,7 +4497,11 @@
       "small": "https://images.pokemontcg.io/sv1/71.png",
       "large": "https://images.pokemontcg.io/sv1/71_hires.png"
     },
-    "flavorText": "This selfish, attention-seeking Pokémon stores poison and electricity in two different sacs inside its body."
+    "flavorText": "This selfish, attention-seeking Pokémon stores poison and electricity in two different sacs inside its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-72",
@@ -4261,7 +4565,11 @@
       "small": "https://images.pokemontcg.io/sv1/72.png",
       "large": "https://images.pokemontcg.io/sv1/72_hires.png"
     },
-    "flavorText": "The jolts of electricity it launches by violently strumming the protrusions on its chest easily exceed 15,000 volts."
+    "flavorText": "The jolts of electricity it launches by violently strumming the protrusions on its chest easily exceed 15,000 volts.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-73",
@@ -4311,7 +4619,11 @@
       "small": "https://images.pokemontcg.io/sv1/73.png",
       "large": "https://images.pokemontcg.io/sv1/73_hires.png"
     },
-    "flavorText": "The pads of its paws are electricity-discharging organs. Pawmi fires electricity from its forepaws while standing unsteadily on its hind legs."
+    "flavorText": "The pads of its paws are electricity-discharging organs. Pawmi fires electricity from its forepaws while standing unsteadily on its hind legs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-74",
@@ -4371,7 +4683,11 @@
       "small": "https://images.pokemontcg.io/sv1/74.png",
       "large": "https://images.pokemontcg.io/sv1/74_hires.png"
     },
-    "flavorText": "The pads of its paws are electricity-discharging organs. Pawmi fires electricity from its forepaws while standing unsteadily on its hind legs."
+    "flavorText": "The pads of its paws are electricity-discharging organs. Pawmi fires electricity from its forepaws while standing unsteadily on its hind legs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-75",
@@ -4433,7 +4749,11 @@
       "small": "https://images.pokemontcg.io/sv1/75.png",
       "large": "https://images.pokemontcg.io/sv1/75_hires.png"
     },
-    "flavorText": "Pawmo uses a unique fighting technique in which it uses its forepaws to strike foes and zap them with electricity from its paw pads simultaneously."
+    "flavorText": "Pawmo uses a unique fighting technique in which it uses its forepaws to strike foes and zap them with electricity from its paw pads simultaneously.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-76",
@@ -4489,7 +4809,14 @@
       "small": "https://images.pokemontcg.io/sv1/76.png",
       "large": "https://images.pokemontcg.io/sv1/76_hires.png"
     },
-    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
+    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon",
+      "Vertical Line Holo"
+    ]
   },
   {
     "id": "sv1-77",
@@ -4555,7 +4882,11 @@
       "small": "https://images.pokemontcg.io/sv1/77.png",
       "large": "https://images.pokemontcg.io/sv1/77_hires.png"
     },
-    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them."
+    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-78",
@@ -4611,7 +4942,11 @@
       "small": "https://images.pokemontcg.io/sv1/78.png",
       "large": "https://images.pokemontcg.io/sv1/78_hires.png"
     },
-    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them."
+    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-79",
@@ -4680,7 +5015,11 @@
       "small": "https://images.pokemontcg.io/sv1/79.png",
       "large": "https://images.pokemontcg.io/sv1/79_hires.png"
     },
-    "flavorText": "Kilowattrel inflates its throat sac to amplify its electricity. By riding the wind, this Pokémon can fly over 430 miles in a day."
+    "flavorText": "Kilowattrel inflates its throat sac to amplify its electricity. By riding the wind, this Pokémon can fly over 430 miles in a day.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-80",
@@ -4742,7 +5081,12 @@
       "small": "https://images.pokemontcg.io/sv1/80.png",
       "large": "https://images.pokemontcg.io/sv1/80_hires.png"
     },
-    "flavorText": "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful."
+    "flavorText": "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv1-81",
@@ -4805,7 +5149,12 @@
       "small": "https://images.pokemontcg.io/sv1/81.png",
       "large": "https://images.pokemontcg.io/sv1/81_hires.png"
     },
-    "flavorText": "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful."
+    "flavorText": "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful.",
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-82",
@@ -4872,7 +5221,11 @@
       "small": "https://images.pokemontcg.io/sv1/82.png",
       "large": "https://images.pokemontcg.io/sv1/82_hires.png"
     },
-    "flavorText": "When it twitches its nose, it can tell where someone is sleeping and what that person is dreaming about."
+    "flavorText": "When it twitches its nose, it can tell where someone is sleeping and what that person is dreaming about.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-83",
@@ -4941,7 +5294,11 @@
       "small": "https://images.pokemontcg.io/sv1/83.png",
       "large": "https://images.pokemontcg.io/sv1/83_hires.png"
     },
-    "flavorText": "Always holding a pendulum that it swings at a steady rhythm, it causes drowsiness in anyone nearby."
+    "flavorText": "Always holding a pendulum that it swings at a steady rhythm, it causes drowsiness in anyone nearby.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-84",
@@ -4998,7 +5355,11 @@
       "small": "https://images.pokemontcg.io/sv1/84.png",
       "large": "https://images.pokemontcg.io/sv1/84_hires.png"
     },
-    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions."
+    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-85",
@@ -5067,7 +5428,11 @@
       "small": "https://images.pokemontcg.io/sv1/85.png",
       "large": "https://images.pokemontcg.io/sv1/85_hires.png"
     },
-    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future."
+    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-86",
@@ -5138,7 +5503,12 @@
       "small": "https://images.pokemontcg.io/sv1/86.png",
       "large": "https://images.pokemontcg.io/sv1/86_hires.png"
     },
-    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future."
+    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-87",
@@ -5194,7 +5564,12 @@
       "small": "https://images.pokemontcg.io/sv1/87.png",
       "large": "https://images.pokemontcg.io/sv1/87_hires.png"
     },
-    "flavorText": "It feeds on the dark emotions of sadness and hatred, which make it grow steadily stronger."
+    "flavorText": "It feeds on the dark emotions of sadness and hatred, which make it grow steadily stronger.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-88",
@@ -5266,7 +5641,12 @@
       "small": "https://images.pokemontcg.io/sv1/88.png",
       "large": "https://images.pokemontcg.io/sv1/88_hires.png"
     },
-    "flavorText": "It feeds on the dark emotions of sadness and hatred, which make it grow steadily stronger."
+    "flavorText": "It feeds on the dark emotions of sadness and hatred, which make it grow steadily stronger.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon",
+      "Jumbo"
+    ]
   },
   {
     "id": "sv1-89",
@@ -5333,7 +5713,13 @@
       "small": "https://images.pokemontcg.io/sv1/89.png",
       "large": "https://images.pokemontcg.io/sv1/89_hires.png"
     },
-    "flavorText": "It is whispered that any child who mistakes Drifloon for a balloon and holds on to it could wind up missing."
+    "flavorText": "It is whispered that any child who mistakes Drifloon for a balloon and holds on to it could wind up missing.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-90",
@@ -5402,7 +5788,12 @@
       "small": "https://images.pokemontcg.io/sv1/90.png",
       "large": "https://images.pokemontcg.io/sv1/90_hires.png"
     },
-    "flavorText": "It can generate and release gas within its body. That's how it can control the altitude of its drift."
+    "flavorText": "It can generate and release gas within its body. That's how it can control the altitude of its drift.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-91",
@@ -5452,7 +5843,11 @@
       "small": "https://images.pokemontcg.io/sv1/91.png",
       "large": "https://images.pokemontcg.io/sv1/91_hires.png"
     },
-    "flavorText": "This Flabébé rides a red flower. Immediately after birth, this Pokémon begins flying around in search of a flower it likes."
+    "flavorText": "This Flabébé rides a red flower. Immediately after birth, this Pokémon begins flying around in search of a flower it likes.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-92",
@@ -5504,7 +5899,11 @@
       "small": "https://images.pokemontcg.io/sv1/92.png",
       "large": "https://images.pokemontcg.io/sv1/92_hires.png"
     },
-    "flavorText": "This Pokémon uses red wavelengths of light to pour its own energy into flowers and draw forth their latent potential."
+    "flavorText": "This Pokémon uses red wavelengths of light to pour its own energy into flowers and draw forth their latent potential.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-93",
@@ -5565,7 +5964,11 @@
       "small": "https://images.pokemontcg.io/sv1/93.png",
       "large": "https://images.pokemontcg.io/sv1/93_hires.png"
     },
-    "flavorText": "They say that flower gardens created by Florges are constantly showered with a power that can heal both body and spirit."
+    "flavorText": "They say that flower gardens created by Florges are constantly showered with a power that can heal both body and spirit.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-94",
@@ -5615,7 +6018,11 @@
       "small": "https://images.pokemontcg.io/sv1/94.png",
       "large": "https://images.pokemontcg.io/sv1/94_hires.png"
     },
-    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself."
+    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-95",
@@ -5666,7 +6073,11 @@
       "small": "https://images.pokemontcg.io/sv1/95.png",
       "large": "https://images.pokemontcg.io/sv1/95_hires.png"
     },
-    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself."
+    "flavorText": "It's small and its electricity-generating organ is not fully developed, so it uses its tail to absorb electricity from people's homes and charge itself.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-96",
@@ -5723,7 +6134,13 @@
       "small": "https://images.pokemontcg.io/sv1/96.png",
       "large": "https://images.pokemontcg.io/sv1/96_hires.png"
     },
-    "flavorText": "In the past, noble families entrusted their vault keys to a Klefki. They passed the Klefki down through the generations, taking good care of it."
+    "flavorText": "In the past, noble families entrusted their vault keys to a Klefki. They passed the Klefki down through the generations, taking good care of it.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-97",
@@ -5774,7 +6191,11 @@
       "small": "https://images.pokemontcg.io/sv1/97.png",
       "large": "https://images.pokemontcg.io/sv1/97_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-98",
@@ -5836,7 +6257,11 @@
       "small": "https://images.pokemontcg.io/sv1/98.png",
       "large": "https://images.pokemontcg.io/sv1/98_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-99",
@@ -5896,7 +6321,11 @@
       "small": "https://images.pokemontcg.io/sv1/99.png",
       "large": "https://images.pokemontcg.io/sv1/99_hires.png"
     },
-    "flavorText": "The pleasant aroma that emanates from this Pokémon's body helps wheat grow, so Dachsbun has been treasured by farming villages."
+    "flavorText": "The pleasant aroma that emanates from this Pokémon's body helps wheat grow, so Dachsbun has been treasured by farming villages.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-100",
@@ -5948,7 +6377,11 @@
       "small": "https://images.pokemontcg.io/sv1/100.png",
       "large": "https://images.pokemontcg.io/sv1/100_hires.png"
     },
-    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-101",
@@ -6004,7 +6437,11 @@
       "small": "https://images.pokemontcg.io/sv1/101.png",
       "large": "https://images.pokemontcg.io/sv1/101_hires.png"
     },
-    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-102",
@@ -6060,7 +6497,11 @@
       "small": "https://images.pokemontcg.io/sv1/102.png",
       "large": "https://images.pokemontcg.io/sv1/102_hires.png"
     },
-    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly."
+    "flavorText": "Flittle's toes levitate about half an inch above the ground because of the psychic power emitted from the frills on the Pokémon's belly.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-103",
@@ -6124,7 +6565,11 @@
       "small": "https://images.pokemontcg.io/sv1/103.png",
       "large": "https://images.pokemontcg.io/sv1/103_hires.png"
     },
-    "flavorText": "It immobilizes opponents by bathing them in psychic power from its large eyes. Despite its appearance, it has a vicious temperament."
+    "flavorText": "It immobilizes opponents by bathing them in psychic power from its large eyes. Despite its appearance, it has a vicious temperament.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-104",
@@ -6181,7 +6626,12 @@
       "small": "https://images.pokemontcg.io/sv1/104.png",
       "large": "https://images.pokemontcg.io/sv1/104_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-105",
@@ -6251,7 +6701,12 @@
       "small": "https://images.pokemontcg.io/sv1/105.png",
       "large": "https://images.pokemontcg.io/sv1/105_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv1-106",
@@ -6311,7 +6766,12 @@
       "small": "https://images.pokemontcg.io/sv1/106.png",
       "large": "https://images.pokemontcg.io/sv1/106_hires.png"
     },
-    "flavorText": "A lovingly mourned Pokémon was reborn as Houndstone. It doesn't like anyone touching the protuberance atop its head."
+    "flavorText": "A lovingly mourned Pokémon was reborn as Houndstone. It doesn't like anyone touching the protuberance atop its head.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv1-107",
@@ -6361,7 +6821,11 @@
       "small": "https://images.pokemontcg.io/sv1/107.png",
       "large": "https://images.pokemontcg.io/sv1/107_hires.png"
     },
-    "flavorText": "It is extremely quick to anger. It could be docile one moment, then thrashing away the next instant."
+    "flavorText": "It is extremely quick to anger. It could be docile one moment, then thrashing away the next instant.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-108",
@@ -6412,7 +6876,11 @@
       "small": "https://images.pokemontcg.io/sv1/108.png",
       "large": "https://images.pokemontcg.io/sv1/108_hires.png"
     },
-    "flavorText": "Some researchers theorize that Primeape remains angry even when inside a Poké Ball."
+    "flavorText": "Some researchers theorize that Primeape remains angry even when inside a Poké Ball.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-109",
@@ -6474,7 +6942,13 @@
       "small": "https://images.pokemontcg.io/sv1/109.png",
       "large": "https://images.pokemontcg.io/sv1/109_hires.png"
     },
-    "flavorText": "It imbues its fists with the power of the rage that it kept hidden in its heart. Opponents struck by these imbued fists will be shattered to their core."
+    "flavorText": "It imbues its fists with the power of the rage that it kept hidden in its heart. Opponents struck by these imbued fists will be shattered to their core.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-110",
@@ -6524,7 +6998,11 @@
       "small": "https://images.pokemontcg.io/sv1/110.png",
       "large": "https://images.pokemontcg.io/sv1/110_hires.png"
     },
-    "flavorText": "It never skips its daily yoga training. It heightens its inner strength through meditation."
+    "flavorText": "It never skips its daily yoga training. It heightens its inner strength through meditation.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-111",
@@ -6584,7 +7062,11 @@
       "small": "https://images.pokemontcg.io/sv1/111.png",
       "large": "https://images.pokemontcg.io/sv1/111_hires.png"
     },
-    "flavorText": "Through yoga training, it gained the psychic power to predict its foe's next move."
+    "flavorText": "Through yoga training, it gained the psychic power to predict its foe's next move.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-112",
@@ -6644,7 +7126,11 @@
       "small": "https://images.pokemontcg.io/sv1/112.png",
       "large": "https://images.pokemontcg.io/sv1/112_hires.png"
     },
-    "flavorText": "They communicate with one another using their auras. They are able to run all through the night."
+    "flavorText": "They communicate with one another using their auras. They are able to run all through the night.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-113",
@@ -6704,7 +7190,11 @@
       "small": "https://images.pokemontcg.io/sv1/113.png",
       "large": "https://images.pokemontcg.io/sv1/113_hires.png"
     },
-    "flavorText": "They communicate with one another using their auras. They are able to run all through the night."
+    "flavorText": "They communicate with one another using their auras. They are able to run all through the night.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-114",
@@ -6767,7 +7257,12 @@
       "small": "https://images.pokemontcg.io/sv1/114.png",
       "large": "https://images.pokemontcg.io/sv1/114_hires.png"
     },
-    "flavorText": "It's said that no foe can remain invisible to Lucario, since it can detect auras—even those of foes it could not otherwise see."
+    "flavorText": "It's said that no foe can remain invisible to Lucario, since it can detect auras—even those of foes it could not otherwise see.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-115",
@@ -6828,7 +7323,11 @@
       "small": "https://images.pokemontcg.io/sv1/115.png",
       "large": "https://images.pokemontcg.io/sv1/115_hires.png"
     },
-    "flavorText": "It submerges itself in sand and moves as if swimming. This wise behavior keeps its enemies from finding it and maintains its temperature."
+    "flavorText": "It submerges itself in sand and moves as if swimming. This wise behavior keeps its enemies from finding it and maintains its temperature.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-116",
@@ -6890,7 +7389,11 @@
       "small": "https://images.pokemontcg.io/sv1/116.png",
       "large": "https://images.pokemontcg.io/sv1/116_hires.png"
     },
-    "flavorText": "Protected by thin membranes, their eyes can see even in the dead of night. They live in groups of a few individuals."
+    "flavorText": "Protected by thin membranes, their eyes can see even in the dead of night. They live in groups of a few individuals.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-117",
@@ -6953,7 +7456,11 @@
       "small": "https://images.pokemontcg.io/sv1/117.png",
       "large": "https://images.pokemontcg.io/sv1/117_hires.png"
     },
-    "flavorText": "After clamping down with its powerful jaws, it twists its body around to rip its prey in half."
+    "flavorText": "After clamping down with its powerful jaws, it twists its body around to rip its prey in half.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-118",
@@ -7012,7 +7519,13 @@
       "small": "https://images.pokemontcg.io/sv1/118.png",
       "large": "https://images.pokemontcg.io/sv1/118_hires.png"
     },
-    "flavorText": "Its elegant finishing moves—performed by nimbly leaping around using its wings—are polished in the forest where it was born and raised."
+    "flavorText": "Its elegant finishing moves—performed by nimbly leaping around using its wings—are polished in the forest where it was born and raised.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-119",
@@ -7064,7 +7577,11 @@
       "small": "https://images.pokemontcg.io/sv1/119.png",
       "large": "https://images.pokemontcg.io/sv1/119_hires.png"
     },
-    "flavorText": "Silicobra's neck pouch, which can inflate and deflate like a balloon, gets more elastic each time Silicobra sheds its skin."
+    "flavorText": "Silicobra's neck pouch, which can inflate and deflate like a balloon, gets more elastic each time Silicobra sheds its skin.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-120",
@@ -7131,7 +7648,11 @@
       "small": "https://images.pokemontcg.io/sv1/120.png",
       "large": "https://images.pokemontcg.io/sv1/120_hires.png"
     },
-    "flavorText": "It will expand its body as much as it can and then contract itself, blasting out sand with enough force to wash away a dump truck."
+    "flavorText": "It will expand its body as much as it can and then contract itself, blasting out sand with enough force to wash away a dump truck.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-121",
@@ -7191,7 +7712,11 @@
       "small": "https://images.pokemontcg.io/sv1/121.png",
       "large": "https://images.pokemontcg.io/sv1/121_hires.png"
     },
-    "flavorText": "The elemental composition of the rocks that form its body were found to match the bedrock of a land far away from this Pokémon's habitat."
+    "flavorText": "The elemental composition of the rocks that form its body were found to match the bedrock of a land far away from this Pokémon's habitat.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-122",
@@ -7255,7 +7780,12 @@
       "small": "https://images.pokemontcg.io/sv1/122.png",
       "large": "https://images.pokemontcg.io/sv1/122_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv1-123",
@@ -7323,7 +7853,11 @@
       "small": "https://images.pokemontcg.io/sv1/123.png",
       "large": "https://images.pokemontcg.io/sv1/123_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-124",
@@ -7388,7 +7922,12 @@
       "small": "https://images.pokemontcg.io/sv1/124.png",
       "large": "https://images.pokemontcg.io/sv1/124_hires.png"
     },
-    "flavorText": "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists."
+    "flavorText": "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv1-125",
@@ -7452,7 +7991,12 @@
       "small": "https://images.pokemontcg.io/sv1/125.png",
       "large": "https://images.pokemontcg.io/sv1/125_hires.png"
     },
-    "flavorText": "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists."
+    "flavorText": "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists.",
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-126",
@@ -7506,7 +8050,11 @@
       "small": "https://images.pokemontcg.io/sv1/126.png",
       "large": "https://images.pokemontcg.io/sv1/126_hires.png"
     },
-    "flavorText": "Born from sludge, these Pokémon now gather in polluted places and increase the bacteria in their bodies."
+    "flavorText": "Born from sludge, these Pokémon now gather in polluted places and increase the bacteria in their bodies.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-127",
@@ -7570,7 +8118,12 @@
       "small": "https://images.pokemontcg.io/sv1/127.png",
       "large": "https://images.pokemontcg.io/sv1/127_hires.png"
     },
-    "flavorText": "It's thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison."
+    "flavorText": "It's thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-128",
@@ -7632,7 +8185,11 @@
       "small": "https://images.pokemontcg.io/sv1/128.png",
       "large": "https://images.pokemontcg.io/sv1/128_hires.png"
     },
-    "flavorText": "It sharpens its swordlike tail on hard rocks. It hides in tall grass and strikes unwary prey with venomous fangs."
+    "flavorText": "It sharpens its swordlike tail on hard rocks. It hides in tall grass and strikes unwary prey with venomous fangs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-129",
@@ -7692,7 +8249,12 @@
       "small": "https://images.pokemontcg.io/sv1/129.png",
       "large": "https://images.pokemontcg.io/sv1/129_hires.png"
     },
-    "flavorText": "It was formed by uniting 108 spirits. It has been bound to the Odd Keystone to keep it from doing any mischief."
+    "flavorText": "It was formed by uniting 108 spirits. It has been bound to the Odd Keystone to keep it from doing any mischief.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv1-130",
@@ -7753,7 +8315,11 @@
       "small": "https://images.pokemontcg.io/sv1/130.png",
       "large": "https://images.pokemontcg.io/sv1/130_hires.png"
     },
-    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab."
+    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-131",
@@ -7820,7 +8386,11 @@
       "small": "https://images.pokemontcg.io/sv1/131.png",
       "large": "https://images.pokemontcg.io/sv1/131_hires.png"
     },
-    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab."
+    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-132",
@@ -7880,7 +8450,11 @@
       "small": "https://images.pokemontcg.io/sv1/132.png",
       "large": "https://images.pokemontcg.io/sv1/132_hires.png"
     },
-    "flavorText": "Pawniard will fearlessly challenge even powerful foes. In a pinch, it will cling to opponents and pierce them with the blades all over its body."
+    "flavorText": "Pawniard will fearlessly challenge even powerful foes. In a pinch, it will cling to opponents and pierce them with the blades all over its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-133",
@@ -7941,7 +8515,11 @@
       "small": "https://images.pokemontcg.io/sv1/133.png",
       "large": "https://images.pokemontcg.io/sv1/133_hires.png"
     },
-    "flavorText": "This Pokémon commands a group of several Pawniard. Groups that are defeated in territorial disputes are absorbed by the winning side."
+    "flavorText": "This Pokémon commands a group of several Pawniard. Groups that are defeated in territorial disputes are absorbed by the winning side.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-134",
@@ -8003,7 +8581,12 @@
       "small": "https://images.pokemontcg.io/sv1/134.png",
       "large": "https://images.pokemontcg.io/sv1/134_hires.png"
     },
-    "flavorText": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit."
+    "flavorText": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-135",
@@ -8064,7 +8647,11 @@
       "small": "https://images.pokemontcg.io/sv1/135.png",
       "large": "https://images.pokemontcg.io/sv1/135_hires.png"
     },
-    "flavorText": "Its well-developed jaw and fangs are strong enough to crunch through boulders, and its thick fat makes for an excellent defense."
+    "flavorText": "Its well-developed jaw and fangs are strong enough to crunch through boulders, and its thick fat makes for an excellent defense.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-136",
@@ -8117,7 +8704,11 @@
       "small": "https://images.pokemontcg.io/sv1/136.png",
       "large": "https://images.pokemontcg.io/sv1/136_hires.png"
     },
-    "flavorText": "Its well-developed jaw and fangs are strong enough to crunch through boulders, and its thick fat makes for an excellent defense."
+    "flavorText": "Its well-developed jaw and fangs are strong enough to crunch through boulders, and its thick fat makes for an excellent defense.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-137",
@@ -8179,7 +8770,11 @@
       "small": "https://images.pokemontcg.io/sv1/137.png",
       "large": "https://images.pokemontcg.io/sv1/137_hires.png"
     },
-    "flavorText": "Mabosstiff loves playing with children. Though usually gentle, it takes on an intimidating look when protecting its family."
+    "flavorText": "Mabosstiff loves playing with children. Though usually gentle, it takes on an intimidating look when protecting its family.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-138",
@@ -8245,7 +8840,11 @@
       "small": "https://images.pokemontcg.io/sv1/138.png",
       "large": "https://images.pokemontcg.io/sv1/138_hires.png"
     },
-    "flavorText": "Bombirdier uses the apron on its chest to bundle up food, which it carries back to its nest. It enjoys dropping things that make loud noises."
+    "flavorText": "Bombirdier uses the apron on its chest to bundle up food, which it carries back to its nest. It enjoys dropping things that make loud noises.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-139",
@@ -8315,7 +8914,11 @@
       "small": "https://images.pokemontcg.io/sv1/139.png",
       "large": "https://images.pokemontcg.io/sv1/139_hires.png"
     },
-    "flavorText": "Its entire body is shielded by a steel-hard shell. What lurks inside this shell is a total mystery."
+    "flavorText": "Its entire body is shielded by a steel-hard shell. What lurks inside this shell is a total mystery.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-140",
@@ -8371,7 +8974,11 @@
       "small": "https://images.pokemontcg.io/sv1/140.png",
       "large": "https://images.pokemontcg.io/sv1/140_hires.png"
     },
-    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory."
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-141",
@@ -8430,7 +9037,11 @@
       "small": "https://images.pokemontcg.io/sv1/141.png",
       "large": "https://images.pokemontcg.io/sv1/141_hires.png"
     },
-    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory."
+    "flavorText": "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-142",
@@ -8498,7 +9109,13 @@
       "small": "https://images.pokemontcg.io/sv1/142.png",
       "large": "https://images.pokemontcg.io/sv1/142_hires.png"
     },
-    "flavorText": "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders— now numbering eight—to generate energy."
+    "flavorText": "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders— now numbering eight—to generate energy.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-143",
@@ -8574,7 +9191,11 @@
       "small": "https://images.pokemontcg.io/sv1/143.png",
       "large": "https://images.pokemontcg.io/sv1/143_hires.png"
     },
-    "flavorText": "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders— now numbering eight—to generate energy."
+    "flavorText": "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders— now numbering eight—to generate energy.",
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-144",
@@ -8637,7 +9258,11 @@
       "small": "https://images.pokemontcg.io/sv1/144.png",
       "large": "https://images.pokemontcg.io/sv1/144_hires.png"
     },
-    "flavorText": "It walks carefully to prevent its egg from breaking. However, it is extremely fast at running away."
+    "flavorText": "It walks carefully to prevent its egg from breaking. However, it is extremely fast at running away.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-145",
@@ -8698,7 +9323,11 @@
       "small": "https://images.pokemontcg.io/sv1/145.png",
       "large": "https://images.pokemontcg.io/sv1/145_hires.png"
     },
-    "flavorText": "The eggs it lays are filled with happiness. Eating even one bite will bring a smile to anyone."
+    "flavorText": "The eggs it lays are filled with happiness. Eating even one bite will bring a smile to anyone.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-146",
@@ -8748,7 +9377,11 @@
       "small": "https://images.pokemontcg.io/sv1/146.png",
       "large": "https://images.pokemontcg.io/sv1/146_hires.png"
     },
-    "flavorText": "The eggs it lays are filled with happiness. Eating even one bite will bring a smile to anyone."
+    "flavorText": "The eggs it lays are filled with happiness. Eating even one bite will bring a smile to anyone.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-147",
@@ -8811,7 +9444,11 @@
       "small": "https://images.pokemontcg.io/sv1/147.png",
       "large": "https://images.pokemontcg.io/sv1/147_hires.png"
     },
-    "flavorText": "It's Seviper's archrival. To threaten those it encounters, it fans out the claws on its front paws."
+    "flavorText": "It's Seviper's archrival. To threaten those it encounters, it fans out the claws on its front paws.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-148",
@@ -8867,7 +9504,11 @@
       "small": "https://images.pokemontcg.io/sv1/148.png",
       "large": "https://images.pokemontcg.io/sv1/148_hires.png"
     },
-    "flavorText": "They flock around mountains and fields, chasing after bug Pokémon. Their singing is noisy and annoying."
+    "flavorText": "They flock around mountains and fields, chasing after bug Pokémon. Their singing is noisy and annoying.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-149",
@@ -8936,7 +9577,11 @@
       "small": "https://images.pokemontcg.io/sv1/149.png",
       "large": "https://images.pokemontcg.io/sv1/149_hires.png"
     },
-    "flavorText": "Recognizing their own weakness, they always live in a group. When alone, a Staravia cries noisily."
+    "flavorText": "Recognizing their own weakness, they always live in a group. When alone, a Staravia cries noisily.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-150",
@@ -9005,7 +9650,11 @@
       "small": "https://images.pokemontcg.io/sv1/150.png",
       "large": "https://images.pokemontcg.io/sv1/150_hires.png"
     },
-    "flavorText": "When Staravia evolve into Staraptor, they leave the flock to live alone. They have sturdy wings."
+    "flavorText": "When Staravia evolve into Staraptor, they leave the flock to live alone. They have sturdy wings.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-151",
@@ -9063,7 +9712,12 @@
       "small": "https://images.pokemontcg.io/sv1/151.png",
       "large": "https://images.pokemontcg.io/sv1/151_hires.png"
     },
-    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail."
+    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-152",
@@ -9127,7 +9781,11 @@
       "small": "https://images.pokemontcg.io/sv1/152.png",
       "large": "https://images.pokemontcg.io/sv1/152_hires.png"
     },
-    "flavorText": "This Pokémon makes off with heaps of fallen berries by wrapping them in its tail, which is roughly twice the length of its body."
+    "flavorText": "This Pokémon makes off with heaps of fallen berries by wrapping them in its tail, which is roughly twice the length of its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-153",
@@ -9187,7 +9845,12 @@
       "small": "https://images.pokemontcg.io/sv1/153.png",
       "large": "https://images.pokemontcg.io/sv1/153_hires.png"
     },
-    "flavorText": "In search of happy feelings—such as joy and gratitude—Indeedee bustles around, taking diligent care of people and other Pokémon."
+    "flavorText": "In search of happy feelings—such as joy and gratitude—Indeedee bustles around, taking diligent care of people and other Pokémon.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv1-154",
@@ -9247,7 +9910,15 @@
       "small": "https://images.pokemontcg.io/sv1/154.png",
       "large": "https://images.pokemontcg.io/sv1/154_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "EB Games",
+      "GameStop",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv1-155",
@@ -9308,7 +9979,12 @@
       "small": "https://images.pokemontcg.io/sv1/155.png",
       "large": "https://images.pokemontcg.io/sv1/155_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Pokémon Center"
+    ]
   },
   {
     "id": "sv1-156",
@@ -9360,7 +10036,12 @@
       "small": "https://images.pokemontcg.io/sv1/156.png",
       "large": "https://images.pokemontcg.io/sv1/156_hires.png"
     },
-    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging."
+    "flavorText": "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv1-157",
@@ -9424,7 +10105,11 @@
       "small": "https://images.pokemontcg.io/sv1/157.png",
       "large": "https://images.pokemontcg.io/sv1/157_hires.png"
     },
-    "flavorText": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail."
+    "flavorText": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-158",
@@ -9491,7 +10176,12 @@
       "small": "https://images.pokemontcg.io/sv1/158.png",
       "large": "https://images.pokemontcg.io/sv1/158_hires.png"
     },
-    "flavorText": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail."
+    "flavorText": "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail.",
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-159",
@@ -9541,7 +10231,11 @@
       "small": "https://images.pokemontcg.io/sv1/159.png",
       "large": "https://images.pokemontcg.io/sv1/159_hires.png"
     },
-    "flavorText": "The pair sticks together no matter what. They split any food they find exactly in half and then eat it together."
+    "flavorText": "The pair sticks together no matter what. They split any food they find exactly in half and then eat it together.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-160",
@@ -9592,7 +10286,11 @@
       "small": "https://images.pokemontcg.io/sv1/160.png",
       "large": "https://images.pokemontcg.io/sv1/160_hires.png"
     },
-    "flavorText": "The pair sticks together no matter what. They split any food they find exactly in half and then eat it together."
+    "flavorText": "The pair sticks together no matter what. They split any food they find exactly in half and then eat it together.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-161",
@@ -9653,7 +10351,11 @@
       "small": "https://images.pokemontcg.io/sv1/161.png",
       "large": "https://images.pokemontcg.io/sv1/161_hires.png"
     },
-    "flavorText": "The larger pair protects the little ones during battles. When facing strong opponents, the whole group will join the fight."
+    "flavorText": "The larger pair protects the little ones during battles. When facing strong opponents, the whole group will join the fight.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-162",
@@ -9719,7 +10421,11 @@
       "small": "https://images.pokemontcg.io/sv1/162.png",
       "large": "https://images.pokemontcg.io/sv1/162_hires.png"
     },
-    "flavorText": "Green-feathered flocks hold the most sway. When they're out searching for food in the mornings and evenings, it gets very noisy."
+    "flavorText": "Green-feathered flocks hold the most sway. When they're out searching for food in the mornings and evenings, it gets very noisy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-163",
@@ -9770,7 +10476,11 @@
       "small": "https://images.pokemontcg.io/sv1/163.png",
       "large": "https://images.pokemontcg.io/sv1/163_hires.png"
     },
-    "flavorText": "Apparently Cyclizar has been allowing people to ride on its back since ancient times. Depictions of this have been found in 10,000-year-old murals."
+    "flavorText": "Apparently Cyclizar has been allowing people to ride on its back since ancient times. Depictions of this have been found in 10,000-year-old murals.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-164",
@@ -9827,7 +10537,12 @@
       "small": "https://images.pokemontcg.io/sv1/164.png",
       "large": "https://images.pokemontcg.io/sv1/164_hires.png"
     },
-    "flavorText": "It can sprint at over 70 mph while carrying a human. The rider's body heat warms Cyclizar's back and lifts the Pokémon's spirit."
+    "flavorText": "It can sprint at over 70 mph while carrying a human. The rider's body heat warms Cyclizar's back and lifts the Pokémon's spirit.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv1-165",
@@ -9894,7 +10609,11 @@
       "small": "https://images.pokemontcg.io/sv1/165.png",
       "large": "https://images.pokemontcg.io/sv1/165_hires.png"
     },
-    "flavorText": "Thanks to a behavior of theirs known as \"synchronizing,\" an entire flock of these Pokémon can attack simultaneously in perfect harmony."
+    "flavorText": "Thanks to a behavior of theirs known as \"synchronizing,\" an entire flock of these Pokémon can attack simultaneously in perfect harmony.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-166",
@@ -9920,7 +10639,15 @@
       "small": "https://images.pokemontcg.io/sv1/166.png",
       "large": "https://images.pokemontcg.io/sv1/166_hires.png"
     },
-    "flavorText": "Thanks to a behavior of theirs known as \"synchronizing,\" an entire flock of these Pokémon can attack simultaneously in perfect harmony."
+    "flavorText": "Thanks to a behavior of theirs known as \"synchronizing,\" an entire flock of these Pokémon can attack simultaneously in perfect harmony.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "Regional Championship",
+      "Regional Championship (Staff)"
+    ]
   },
   {
     "id": "sv1-167",
@@ -9945,7 +10672,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/167.png",
       "large": "https://images.pokemontcg.io/sv1/167_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-168",
@@ -9970,7 +10703,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/168.png",
       "large": "https://images.pokemontcg.io/sv1/168_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-169",
@@ -9995,7 +10732,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/169.png",
       "large": "https://images.pokemontcg.io/sv1/169_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-170",
@@ -10020,7 +10762,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/170.png",
       "large": "https://images.pokemontcg.io/sv1/170_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-171",
@@ -10045,7 +10793,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/171.png",
       "large": "https://images.pokemontcg.io/sv1/171_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-172",
@@ -10070,7 +10822,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/172.png",
       "large": "https://images.pokemontcg.io/sv1/172_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-173",
@@ -10095,7 +10851,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/173.png",
       "large": "https://images.pokemontcg.io/sv1/173_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-174",
@@ -10120,7 +10880,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/174.png",
       "large": "https://images.pokemontcg.io/sv1/174_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-175",
@@ -10145,7 +10909,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/175.png",
       "large": "https://images.pokemontcg.io/sv1/175_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-176",
@@ -10170,7 +10940,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/176.png",
       "large": "https://images.pokemontcg.io/sv1/176_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Professor Program",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-177",
@@ -10195,7 +10972,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/177.png",
       "large": "https://images.pokemontcg.io/sv1/177_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-178",
@@ -10220,7 +11001,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/178.png",
       "large": "https://images.pokemontcg.io/sv1/178_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-179",
@@ -10245,7 +11030,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/179.png",
       "large": "https://images.pokemontcg.io/sv1/179_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-180",
@@ -10270,7 +11060,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/180.png",
       "large": "https://images.pokemontcg.io/sv1/180_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-181",
@@ -10295,7 +11089,26 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/181.png",
       "large": "https://images.pokemontcg.io/sv1/181_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Championships Europe",
+      "Championships Europe (Champion)",
+      "Championships Europe (Staff)",
+      "Championships Europe (Top 8)",
+      "Championships Latin America",
+      "Championships Latin America (Champion)",
+      "Championships Latin America (Staff)",
+      "Championships Latin America (Top 8)",
+      "Championships North America",
+      "Championships North America (Champion)",
+      "Championships North America (Staff)",
+      "Championships North America (Top 8)",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-182",
@@ -10320,7 +11133,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/182.png",
       "large": "https://images.pokemontcg.io/sv1/182_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-183",
@@ -10345,7 +11164,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/183.png",
       "large": "https://images.pokemontcg.io/sv1/183_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-184",
@@ -10370,7 +11194,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/184.png",
       "large": "https://images.pokemontcg.io/sv1/184_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-185",
@@ -10395,7 +11223,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/185.png",
       "large": "https://images.pokemontcg.io/sv1/185_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-186",
@@ -10420,7 +11252,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/186.png",
       "large": "https://images.pokemontcg.io/sv1/186_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-187",
@@ -10445,7 +11282,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/187.png",
       "large": "https://images.pokemontcg.io/sv1/187_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-188",
@@ -10470,7 +11311,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/188.png",
       "large": "https://images.pokemontcg.io/sv1/188_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-189",
@@ -10495,7 +11340,16 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/189.png",
       "large": "https://images.pokemontcg.io/sv1/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "Professor Program",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-190",
@@ -10520,7 +11374,16 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/190.png",
       "large": "https://images.pokemontcg.io/sv1/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "Professor Program",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-191",
@@ -10545,7 +11408,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/191.png",
       "large": "https://images.pokemontcg.io/sv1/191_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-192",
@@ -10570,7 +11440,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/192.png",
       "large": "https://images.pokemontcg.io/sv1/192_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-193",
@@ -10595,7 +11469,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/193.png",
       "large": "https://images.pokemontcg.io/sv1/193_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-194",
@@ -10620,7 +11498,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/194.png",
       "large": "https://images.pokemontcg.io/sv1/194_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-195",
@@ -10645,7 +11529,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/195.png",
       "large": "https://images.pokemontcg.io/sv1/195_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv1-196",
@@ -10670,7 +11559,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/196.png",
       "large": "https://images.pokemontcg.io/sv1/196_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv1-197",
@@ -10695,7 +11591,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/197.png",
       "large": "https://images.pokemontcg.io/sv1/197_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-198",
@@ -10720,7 +11620,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/198.png",
       "large": "https://images.pokemontcg.io/sv1/198_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv1-199",
@@ -10771,7 +11675,10 @@
       "small": "https://images.pokemontcg.io/sv1/199.png",
       "large": "https://images.pokemontcg.io/sv1/199_hires.png"
     },
-    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research."
+    "flavorText": "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-200",
@@ -10832,7 +11739,10 @@
       "small": "https://images.pokemontcg.io/sv1/200.png",
       "large": "https://images.pokemontcg.io/sv1/200_hires.png"
     },
-    "flavorText": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone."
+    "flavorText": "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-201",
@@ -10882,7 +11792,10 @@
       "small": "https://images.pokemontcg.io/sv1/201.png",
       "large": "https://images.pokemontcg.io/sv1/201_hires.png"
     },
-    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph."
+    "flavorText": "Though it looks like Tentacool, Toedscool is a completely different species. Its legs may be thin, but it can run at a speed of 30 mph.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-202",
@@ -10944,7 +11857,10 @@
       "small": "https://images.pokemontcg.io/sv1/202.png",
       "large": "https://images.pokemontcg.io/sv1/202_hires.png"
     },
-    "flavorText": "The green head has turned vicious due to the spicy chemicals stimulating its brain. Once it goes on a rampage, there is no stopping it."
+    "flavorText": "The green head has turned vicious due to the spicy chemicals stimulating its brain. Once it goes on a rampage, there is no stopping it.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-203",
@@ -11005,7 +11921,10 @@
       "small": "https://images.pokemontcg.io/sv1/203.png",
       "large": "https://images.pokemontcg.io/sv1/203_hires.png"
     },
-    "flavorText": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal."
+    "flavorText": "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-204",
@@ -11066,7 +11985,10 @@
       "small": "https://images.pokemontcg.io/sv1/204.png",
       "large": "https://images.pokemontcg.io/sv1/204_hires.png"
     },
-    "flavorText": "It is always vacantly lost in thought, but no one knows what it is thinking about. It is good at fishing with its tail."
+    "flavorText": "It is always vacantly lost in thought, but no one knows what it is thinking about. It is good at fishing with its tail.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-205",
@@ -11116,7 +12038,10 @@
       "small": "https://images.pokemontcg.io/sv1/205.png",
       "large": "https://images.pokemontcg.io/sv1/205_hires.png"
     },
-    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes."
+    "flavorText": "Clauncher's claws will regrow if they fall off. The meat inside the claws is edible, but it has a distinct flavor that doesn't appeal to all tastes.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-206",
@@ -11166,7 +12091,10 @@
       "small": "https://images.pokemontcg.io/sv1/206.png",
       "large": "https://images.pokemontcg.io/sv1/206_hires.png"
     },
-    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand."
+    "flavorText": "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-207",
@@ -11232,7 +12160,10 @@
       "small": "https://images.pokemontcg.io/sv1/207.png",
       "large": "https://images.pokemontcg.io/sv1/207_hires.png"
     },
-    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey."
+    "flavorText": "This Pokémon is a glutton, but it's bad at getting food. It teams up with a Tatsugiri to catch prey.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-208",
@@ -11290,7 +12221,10 @@
       "small": "https://images.pokemontcg.io/sv1/208.png",
       "large": "https://images.pokemontcg.io/sv1/208_hires.png"
     },
-    "flavorText": "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity."
+    "flavorText": "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-209",
@@ -11346,7 +12280,10 @@
       "small": "https://images.pokemontcg.io/sv1/209.png",
       "large": "https://images.pokemontcg.io/sv1/209_hires.png"
     },
-    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car."
+    "flavorText": "Pawmot's fluffy fur acts as a battery. It can store the same amount of electricity as an electric car.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-210",
@@ -11413,7 +12350,10 @@
       "small": "https://images.pokemontcg.io/sv1/210.png",
       "large": "https://images.pokemontcg.io/sv1/210_hires.png"
     },
-    "flavorText": "When it twitches its nose, it can tell where someone is sleeping and what that person is dreaming about."
+    "flavorText": "When it twitches its nose, it can tell where someone is sleeping and what that person is dreaming about.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-211",
@@ -11470,7 +12410,10 @@
       "small": "https://images.pokemontcg.io/sv1/211.png",
       "large": "https://images.pokemontcg.io/sv1/211_hires.png"
     },
-    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions."
+    "flavorText": "The horns on its head provide a strong power that enables it to sense people's emotions.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-212",
@@ -11539,7 +12482,10 @@
       "small": "https://images.pokemontcg.io/sv1/212.png",
       "large": "https://images.pokemontcg.io/sv1/212_hires.png"
     },
-    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future."
+    "flavorText": "It has a psychic power that enables it to distort the space around it and see into the future.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-213",
@@ -11601,7 +12547,10 @@
       "small": "https://images.pokemontcg.io/sv1/213.png",
       "large": "https://images.pokemontcg.io/sv1/213_hires.png"
     },
-    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity."
+    "flavorText": "This Pokémon is smooth and moist to the touch. Yeast in Fidough's breath induces fermentation in the Pokémon's vicinity.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-214",
@@ -11658,7 +12607,10 @@
       "small": "https://images.pokemontcg.io/sv1/214.png",
       "large": "https://images.pokemontcg.io/sv1/214_hires.png"
     },
-    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever."
+    "flavorText": "This friendly Pokémon doesn't like being alone. Pay it even the slightest bit of attention, and it will follow you forever.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-215",
@@ -11718,7 +12670,10 @@
       "small": "https://images.pokemontcg.io/sv1/215.png",
       "large": "https://images.pokemontcg.io/sv1/215_hires.png"
     },
-    "flavorText": "They communicate with one another using their auras. They are able to run all through the night."
+    "flavorText": "They communicate with one another using their auras. They are able to run all through the night.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-216",
@@ -11779,7 +12734,10 @@
       "small": "https://images.pokemontcg.io/sv1/216.png",
       "large": "https://images.pokemontcg.io/sv1/216_hires.png"
     },
-    "flavorText": "It submerges itself in sand and moves as if swimming. This wise behavior keeps its enemies from finding it and maintains its temperature."
+    "flavorText": "It submerges itself in sand and moves as if swimming. This wise behavior keeps its enemies from finding it and maintains its temperature.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-217",
@@ -11843,7 +12801,10 @@
       "small": "https://images.pokemontcg.io/sv1/217.png",
       "large": "https://images.pokemontcg.io/sv1/217_hires.png"
     },
-    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head."
+    "flavorText": "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-218",
@@ -11905,7 +12866,10 @@
       "small": "https://images.pokemontcg.io/sv1/218.png",
       "large": "https://images.pokemontcg.io/sv1/218_hires.png"
     },
-    "flavorText": "Mabosstiff loves playing with children. Though usually gentle, it takes on an intimidating look when protecting its family."
+    "flavorText": "Mabosstiff loves playing with children. Though usually gentle, it takes on an intimidating look when protecting its family.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-219",
@@ -11971,7 +12935,10 @@
       "small": "https://images.pokemontcg.io/sv1/219.png",
       "large": "https://images.pokemontcg.io/sv1/219_hires.png"
     },
-    "flavorText": "Bombirdier uses the apron on its chest to bundle up food, which it carries back to its nest. It enjoys dropping things that make loud noises."
+    "flavorText": "Bombirdier uses the apron on its chest to bundle up food, which it carries back to its nest. It enjoys dropping things that make loud noises.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-220",
@@ -12033,7 +13000,10 @@
       "small": "https://images.pokemontcg.io/sv1/220.png",
       "large": "https://images.pokemontcg.io/sv1/220_hires.png"
     },
-    "flavorText": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit."
+    "flavorText": "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-221",
@@ -12089,7 +13059,10 @@
       "small": "https://images.pokemontcg.io/sv1/221.png",
       "large": "https://images.pokemontcg.io/sv1/221_hires.png"
     },
-    "flavorText": "They flock around mountains and fields, chasing after bug Pokémon. Their singing is noisy and annoying."
+    "flavorText": "They flock around mountains and fields, chasing after bug Pokémon. Their singing is noisy and annoying.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-222",
@@ -12147,7 +13120,10 @@
       "small": "https://images.pokemontcg.io/sv1/222.png",
       "large": "https://images.pokemontcg.io/sv1/222_hires.png"
     },
-    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail."
+    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-223",
@@ -12211,7 +13187,10 @@
       "small": "https://images.pokemontcg.io/sv1/223.png",
       "large": "https://images.pokemontcg.io/sv1/223_hires.png"
     },
-    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail."
+    "flavorText": "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-224",
@@ -12281,7 +13260,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/224.png",
       "large": "https://images.pokemontcg.io/sv1/224_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-225",
@@ -12355,7 +13337,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/225.png",
       "large": "https://images.pokemontcg.io/sv1/225_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-226",
@@ -12421,7 +13406,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/226.png",
       "large": "https://images.pokemontcg.io/sv1/226_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-227",
@@ -12483,7 +13471,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/227.png",
       "large": "https://images.pokemontcg.io/sv1/227_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-228",
@@ -12553,7 +13544,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/228.png",
       "large": "https://images.pokemontcg.io/sv1/228_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-229",
@@ -12624,7 +13618,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/229.png",
       "large": "https://images.pokemontcg.io/sv1/229_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-230",
@@ -12691,7 +13688,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/230.png",
       "large": "https://images.pokemontcg.io/sv1/230_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-231",
@@ -12754,7 +13754,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/231.png",
       "large": "https://images.pokemontcg.io/sv1/231_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-232",
@@ -12820,7 +13823,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/232.png",
       "large": "https://images.pokemontcg.io/sv1/232_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-233",
@@ -12895,7 +13901,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/233.png",
       "large": "https://images.pokemontcg.io/sv1/233_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-234",
@@ -12961,7 +13970,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/234.png",
       "large": "https://images.pokemontcg.io/sv1/234_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-235",
@@ -12986,7 +13998,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/235.png",
       "large": "https://images.pokemontcg.io/sv1/235_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-236",
@@ -13011,7 +14026,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/236.png",
       "large": "https://images.pokemontcg.io/sv1/236_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-237",
@@ -13036,7 +14054,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/237.png",
       "large": "https://images.pokemontcg.io/sv1/237_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-238",
@@ -13061,7 +14082,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/238.png",
       "large": "https://images.pokemontcg.io/sv1/238_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-239",
@@ -13086,7 +14110,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/239.png",
       "large": "https://images.pokemontcg.io/sv1/239_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-240",
@@ -13111,7 +14138,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/240.png",
       "large": "https://images.pokemontcg.io/sv1/240_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-241",
@@ -13136,7 +14166,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/241.png",
       "large": "https://images.pokemontcg.io/sv1/241_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-242",
@@ -13161,7 +14194,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/242.png",
       "large": "https://images.pokemontcg.io/sv1/242_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-243",
@@ -13224,7 +14260,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/243.png",
       "large": "https://images.pokemontcg.io/sv1/243_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-244",
@@ -13286,7 +14325,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/244.png",
       "large": "https://images.pokemontcg.io/sv1/244_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-245",
@@ -13356,7 +14398,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/245.png",
       "large": "https://images.pokemontcg.io/sv1/245_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-246",
@@ -13423,7 +14468,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/246.png",
       "large": "https://images.pokemontcg.io/sv1/246_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-247",
@@ -13486,7 +14534,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/247.png",
       "large": "https://images.pokemontcg.io/sv1/247_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-248",
@@ -13561,7 +14612,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/248.png",
       "large": "https://images.pokemontcg.io/sv1/248_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-249",
@@ -13586,7 +14640,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/249.png",
       "large": "https://images.pokemontcg.io/sv1/249_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-250",
@@ -13611,7 +14668,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/250.png",
       "large": "https://images.pokemontcg.io/sv1/250_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-251",
@@ -13636,7 +14696,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/251.png",
       "large": "https://images.pokemontcg.io/sv1/251_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-252",
@@ -13661,7 +14724,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/252.png",
       "large": "https://images.pokemontcg.io/sv1/252_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-253",
@@ -13723,7 +14789,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/253.png",
       "large": "https://images.pokemontcg.io/sv1/253_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-254",
@@ -13786,7 +14855,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/254.png",
       "large": "https://images.pokemontcg.io/sv1/254_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-255",
@@ -13811,7 +14883,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/255.png",
       "large": "https://images.pokemontcg.io/sv1/255_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-256",
@@ -13836,7 +14911,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/256.png",
       "large": "https://images.pokemontcg.io/sv1/256_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-257",
@@ -13855,7 +14933,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/257.png",
       "large": "https://images.pokemontcg.io/sv1/257_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv1-258",
@@ -13874,6 +14955,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv1/258.png",
       "large": "https://images.pokemontcg.io/sv1/258_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv2.json
+++ b/cards/en/sv2.json
@@ -47,7 +47,11 @@
       "small": "https://images.pokemontcg.io/sv2/1.png",
       "large": "https://images.pokemontcg.io/sv2/1_hires.png"
     },
-    "flavorText": "This Pokémon is blown across vast distances by the wind. It is unclear where the Hoppip of Paldea originally came from."
+    "flavorText": "This Pokémon is blown across vast distances by the wind. It is unclear where the Hoppip of Paldea originally came from.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-2",
@@ -105,7 +109,11 @@
       "small": "https://images.pokemontcg.io/sv2/2.png",
       "large": "https://images.pokemontcg.io/sv2/2_hires.png"
     },
-    "flavorText": "Skiploom enthusiasts can apparently tell where a Skiploom was born by the scent drifting from the flower on the Pokémon's head."
+    "flavorText": "Skiploom enthusiasts can apparently tell where a Skiploom was born by the scent drifting from the flower on the Pokémon's head.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-3",
@@ -163,7 +171,11 @@
       "small": "https://images.pokemontcg.io/sv2/3.png",
       "large": "https://images.pokemontcg.io/sv2/3_hires.png"
     },
-    "flavorText": "Jumpluff travels on seasonal winds. Once its cotton spores run out, its journey ends, as does its life."
+    "flavorText": "Jumpluff travels on seasonal winds. Once its cotton spores run out, its journey ends, as does its life.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-4",
@@ -215,7 +227,11 @@
       "small": "https://images.pokemontcg.io/sv2/4.png",
       "large": "https://images.pokemontcg.io/sv2/4_hires.png"
     },
-    "flavorText": "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it."
+    "flavorText": "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-5",
@@ -281,7 +297,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/5.png",
       "large": "https://images.pokemontcg.io/sv2/5_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-6",
@@ -345,7 +365,11 @@
       "small": "https://images.pokemontcg.io/sv2/6.png",
       "large": "https://images.pokemontcg.io/sv2/6_hires.png"
     },
-    "flavorText": "It loves sweet nectar. To keep all the nectar to itself, it hurls rivals away with its prized horn."
+    "flavorText": "It loves sweet nectar. To keep all the nectar to itself, it hurls rivals away with its prized horn.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-7",
@@ -406,7 +430,11 @@
       "small": "https://images.pokemontcg.io/sv2/7.png",
       "large": "https://images.pokemontcg.io/sv2/7_hires.png"
     },
-    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year."
+    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-8",
@@ -456,7 +484,11 @@
       "small": "https://images.pokemontcg.io/sv2/8.png",
       "large": "https://images.pokemontcg.io/sv2/8_hires.png"
     },
-    "flavorText": "At night, Combee sleep in a group of about a hundred, packed closely together in a lump."
+    "flavorText": "At night, Combee sleep in a group of about a hundred, packed closely together in a lump.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-9",
@@ -517,7 +549,11 @@
       "small": "https://images.pokemontcg.io/sv2/9.png",
       "large": "https://images.pokemontcg.io/sv2/9_hires.png"
     },
-    "flavorText": "It houses its colony in cells in its body and releases various pheromones to make those grubs do its bidding."
+    "flavorText": "It houses its colony in cells in its body and releases various pheromones to make those grubs do its bidding.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-10",
@@ -570,7 +606,11 @@
       "small": "https://images.pokemontcg.io/sv2/10.png",
       "large": "https://images.pokemontcg.io/sv2/10_hires.png"
     },
-    "flavorText": "During cold seasons, it migrates to the mountain's lower reaches. It returns to the snow-covered summit in the spring."
+    "flavorText": "During cold seasons, it migrates to the mountain's lower reaches. It returns to the snow-covered summit in the spring.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-11",
@@ -632,7 +672,11 @@
       "small": "https://images.pokemontcg.io/sv2/11.png",
       "large": "https://images.pokemontcg.io/sv2/11_hires.png"
     },
-    "flavorText": "It lives a quiet life on mountains that are perpetually covered in snow. It hides itself by whipping up blizzards."
+    "flavorText": "It lives a quiet life on mountains that are perpetually covered in snow. It hides itself by whipping up blizzards.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-12",
@@ -691,7 +735,11 @@
       "small": "https://images.pokemontcg.io/sv2/12.png",
       "large": "https://images.pokemontcg.io/sv2/12_hires.png"
     },
-    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
+    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-13",
@@ -742,7 +790,12 @@
       "small": "https://images.pokemontcg.io/sv2/13.png",
       "large": "https://images.pokemontcg.io/sv2/13_hires.png"
     },
-    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
+    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv2-14",
@@ -803,7 +856,11 @@
       "small": "https://images.pokemontcg.io/sv2/14.png",
       "large": "https://images.pokemontcg.io/sv2/14_hires.png"
     },
-    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents."
+    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-15",
@@ -866,7 +923,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/15.png",
       "large": "https://images.pokemontcg.io/sv2/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-16",
@@ -916,7 +977,11 @@
       "small": "https://images.pokemontcg.io/sv2/16.png",
       "large": "https://images.pokemontcg.io/sv2/16_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-17",
@@ -968,7 +1033,11 @@
       "small": "https://images.pokemontcg.io/sv2/17.png",
       "large": "https://images.pokemontcg.io/sv2/17_hires.png"
     },
-    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy."
+    "flavorText": "The ball of threads wrapped around its body is elastic enough to deflect the scythes of Scyther, this Pokémon's natural enemy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-18",
@@ -1032,7 +1101,11 @@
       "small": "https://images.pokemontcg.io/sv2/18.png",
       "large": "https://images.pokemontcg.io/sv2/18_hires.png"
     },
-    "flavorText": "It clings to branches and ceilings using its threads and moves without a sound. It takes out its prey before the prey even notices it."
+    "flavorText": "It clings to branches and ceilings using its threads and moves without a sound. It takes out its prey before the prey even notices it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-19",
@@ -1091,7 +1164,11 @@
       "small": "https://images.pokemontcg.io/sv2/19.png",
       "large": "https://images.pokemontcg.io/sv2/19_hires.png"
     },
-    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
+    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-20",
@@ -1141,7 +1218,11 @@
       "small": "https://images.pokemontcg.io/sv2/20.png",
       "large": "https://images.pokemontcg.io/sv2/20_hires.png"
     },
-    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs."
+    "flavorText": "It has its third set of legs folded up. When it's in a tough spot, this Pokémon jumps over 30 feet using the strength of its legs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-21",
@@ -1202,7 +1283,12 @@
       "small": "https://images.pokemontcg.io/sv2/21.png",
       "large": "https://images.pokemontcg.io/sv2/21_hires.png"
     },
-    "flavorText": "When it decides to fight all out, it stands on its previously folded legs to enter Showdown Mode. It neutralizes its enemies in short order."
+    "flavorText": "When it decides to fight all out, it stands on its previously folded legs to enter Showdown Mode. It neutralizes its enemies in short order.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv2-22",
@@ -1252,7 +1338,11 @@
       "small": "https://images.pokemontcg.io/sv2/22.png",
       "large": "https://images.pokemontcg.io/sv2/22_hires.png"
     },
-    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon."
+    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-23",
@@ -1302,7 +1392,11 @@
       "small": "https://images.pokemontcg.io/sv2/23.png",
       "large": "https://images.pokemontcg.io/sv2/23_hires.png"
     },
-    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon."
+    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-24",
@@ -1366,7 +1460,11 @@
       "small": "https://images.pokemontcg.io/sv2/24.png",
       "large": "https://images.pokemontcg.io/sv2/24_hires.png"
     },
-    "flavorText": "It will open the branches of its head to envelop its prey. Once it absorbs all the life energy it needs, it expels the prey and discards it."
+    "flavorText": "It will open the branches of its head to envelop its prey. Once it absorbs all the life energy it needs, it expels the prey and discards it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-25",
@@ -1416,7 +1514,11 @@
       "small": "https://images.pokemontcg.io/sv2/25.png",
       "large": "https://images.pokemontcg.io/sv2/25_hires.png"
     },
-    "flavorText": "This Pokémon creates a mud ball by mixing sand and dirt with psychic energy. It treasures its mud ball more than its own life."
+    "flavorText": "This Pokémon creates a mud ball by mixing sand and dirt with psychic energy. It treasures its mud ball more than its own life.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-26",
@@ -1467,7 +1569,11 @@
       "small": "https://images.pokemontcg.io/sv2/26.png",
       "large": "https://images.pokemontcg.io/sv2/26_hires.png"
     },
-    "flavorText": "This Pokémon creates a mud ball by mixing sand and dirt with psychic energy. It treasures its mud ball more than its own life."
+    "flavorText": "This Pokémon creates a mud ball by mixing sand and dirt with psychic energy. It treasures its mud ball more than its own life.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-27",
@@ -1537,7 +1643,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/27.png",
       "large": "https://images.pokemontcg.io/sv2/27_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-28",
@@ -1600,7 +1709,11 @@
       "small": "https://images.pokemontcg.io/sv2/28.png",
       "large": "https://images.pokemontcg.io/sv2/28_hires.png"
     },
-    "flavorText": "People call this kind of Tauros the Blaze Breed due to the hot air it snorts from its nostrils. Its three tails are intertwined."
+    "flavorText": "People call this kind of Tauros the Blaze Breed due to the hot air it snorts from its nostrils. Its three tails are intertwined.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-29",
@@ -1657,7 +1770,11 @@
       "small": "https://images.pokemontcg.io/sv2/29.png",
       "large": "https://images.pokemontcg.io/sv2/29_hires.png"
     },
-    "flavorText": "Fletchinder scatters embers in tall grass where bug Pokémon might be hiding and then catches them as they come leaping out."
+    "flavorText": "Fletchinder scatters embers in tall grass where bug Pokémon might be hiding and then catches them as they come leaping out.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-30",
@@ -1723,7 +1840,11 @@
       "small": "https://images.pokemontcg.io/sv2/30.png",
       "large": "https://images.pokemontcg.io/sv2/30_hires.png"
     },
-    "flavorText": "It has top-notch flying capabilities. It flies around easily, even while carrying prey that weighs more than 220 lbs."
+    "flavorText": "It has top-notch flying capabilities. It flies around easily, even while carrying prey that weighs more than 220 lbs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-31",
@@ -1782,7 +1903,11 @@
       "small": "https://images.pokemontcg.io/sv2/31.png",
       "large": "https://images.pokemontcg.io/sv2/31_hires.png"
     },
-    "flavorText": "When Litleo are young, female Pyroar will teach them how to hunt. Once the Litleo mature, they will leave the pride and set out on their own."
+    "flavorText": "When Litleo are young, female Pyroar will teach them how to hunt. Once the Litleo mature, they will leave the pride and set out on their own.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-32",
@@ -1844,7 +1969,11 @@
       "small": "https://images.pokemontcg.io/sv2/32.png",
       "large": "https://images.pokemontcg.io/sv2/32_hires.png"
     },
-    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve."
+    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-33",
@@ -1902,7 +2031,11 @@
       "small": "https://images.pokemontcg.io/sv2/33.png",
       "large": "https://images.pokemontcg.io/sv2/33_hires.png"
     },
-    "flavorText": "This Pokémon is incredibly popular, possibly because its passionate dancing is a great match with the temperament of Paldean people."
+    "flavorText": "This Pokémon is incredibly popular, possibly because its passionate dancing is a great match with the temperament of Paldean people.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-34",
@@ -1953,7 +2086,12 @@
       "small": "https://images.pokemontcg.io/sv2/34.png",
       "large": "https://images.pokemontcg.io/sv2/34_hires.png"
     },
-    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy."
+    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv2-35",
@@ -2015,7 +2153,11 @@
       "small": "https://images.pokemontcg.io/sv2/35.png",
       "large": "https://images.pokemontcg.io/sv2/35_hires.png"
     },
-    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy."
+    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-36",
@@ -2078,7 +2220,11 @@
       "small": "https://images.pokemontcg.io/sv2/36.png",
       "large": "https://images.pokemontcg.io/sv2/36_hires.png"
     },
-    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head."
+    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-37",
@@ -2144,7 +2290,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/37.png",
       "large": "https://images.pokemontcg.io/sv2/37_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-38",
@@ -2195,7 +2345,11 @@
       "small": "https://images.pokemontcg.io/sv2/38.png",
       "large": "https://images.pokemontcg.io/sv2/38_hires.png"
     },
-    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents."
+    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-39",
@@ -2257,7 +2411,11 @@
       "small": "https://images.pokemontcg.io/sv2/39.png",
       "large": "https://images.pokemontcg.io/sv2/39_hires.png"
     },
-    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents."
+    "flavorText": "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-40",
@@ -2320,7 +2478,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/40.png",
       "large": "https://images.pokemontcg.io/sv2/40_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-41",
@@ -2383,7 +2544,11 @@
       "small": "https://images.pokemontcg.io/sv2/41.png",
       "large": "https://images.pokemontcg.io/sv2/41_hires.png"
     },
-    "flavorText": "It swims by jetting water from its horns. The most notable characteristic of the Aqua Breed is its high body fat, which allows it to float easily."
+    "flavorText": "It swims by jetting water from its horns. The most notable characteristic of the Aqua Breed is its high body fat, which allows it to float easily.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-42",
@@ -2433,7 +2598,11 @@
       "small": "https://images.pokemontcg.io/sv2/42.png",
       "large": "https://images.pokemontcg.io/sv2/42_hires.png"
     },
-    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet."
+    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-43",
@@ -2501,7 +2670,12 @@
       "small": "https://images.pokemontcg.io/sv2/43.png",
       "large": "https://images.pokemontcg.io/sv2/43_hires.png"
     },
-    "flavorText": "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it."
+    "flavorText": "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-44",
@@ -2552,7 +2726,11 @@
       "small": "https://images.pokemontcg.io/sv2/44.png",
       "large": "https://images.pokemontcg.io/sv2/44_hires.png"
     },
-    "flavorText": "The fur on its body naturally repels water. It can stay dry even when it plays in the water."
+    "flavorText": "The fur on its body naturally repels water. It can stay dry even when it plays in the water.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-45",
@@ -2615,7 +2793,11 @@
       "small": "https://images.pokemontcg.io/sv2/45.png",
       "large": "https://images.pokemontcg.io/sv2/45_hires.png"
     },
-    "flavorText": "Its long ears are superb sensors. It can distinguish the movements of things in water and tell what they are."
+    "flavorText": "Its long ears are superb sensors. It can distinguish the movements of things in water and tell what they are.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-46",
@@ -2675,7 +2857,11 @@
       "small": "https://images.pokemontcg.io/sv2/46.png",
       "large": "https://images.pokemontcg.io/sv2/46_hires.png"
     },
-    "flavorText": "It carries food all day long. There are tales about lost people who were saved by the food it had."
+    "flavorText": "It carries food all day long. There are tales about lost people who were saved by the food it had.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-47",
@@ -2734,7 +2920,11 @@
       "small": "https://images.pokemontcg.io/sv2/47.png",
       "large": "https://images.pokemontcg.io/sv2/47_hires.png"
     },
-    "flavorText": "Its heart-shaped body makes it popular. In some places, you would give a Luvdisc to someone you love."
+    "flavorText": "Its heart-shaped body makes it popular. In some places, you would give a Luvdisc to someone you love.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-48",
@@ -2795,7 +2985,11 @@
       "small": "https://images.pokemontcg.io/sv2/48.png",
       "large": "https://images.pokemontcg.io/sv2/48_hires.png"
     },
-    "flavorText": "On hot days, these Pokémon press their ice cube heads together and pass the time cooling each other down."
+    "flavorText": "On hot days, these Pokémon press their ice cube heads together and pass the time cooling each other down.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-49",
@@ -2846,7 +3040,11 @@
       "small": "https://images.pokemontcg.io/sv2/49.png",
       "large": "https://images.pokemontcg.io/sv2/49_hires.png"
     },
-    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime."
+    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-50",
@@ -2896,7 +3094,12 @@
       "small": "https://images.pokemontcg.io/sv2/50.png",
       "large": "https://images.pokemontcg.io/sv2/50_hires.png"
     },
-    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime."
+    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv2-51",
@@ -2957,7 +3160,11 @@
       "small": "https://images.pokemontcg.io/sv2/51.png",
       "large": "https://images.pokemontcg.io/sv2/51_hires.png"
     },
-    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully."
+    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-52",
@@ -3022,7 +3229,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/52.png",
       "large": "https://images.pokemontcg.io/sv2/52_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-53",
@@ -3075,7 +3285,11 @@
       "small": "https://images.pokemontcg.io/sv2/53.png",
       "large": "https://images.pokemontcg.io/sv2/53_hires.png"
     },
-    "flavorText": "This species left the ocean and began living on land a very long time ago. It seems to be closely related to Wailmer."
+    "flavorText": "This species left the ocean and began living on land a very long time ago. It seems to be closely related to Wailmer.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-54",
@@ -3137,7 +3351,11 @@
       "small": "https://images.pokemontcg.io/sv2/54.png",
       "large": "https://images.pokemontcg.io/sv2/54_hires.png"
     },
-    "flavorText": "This species left the ocean and began living on land a very long time ago. It seems to be closely related to Wailmer."
+    "flavorText": "This species left the ocean and began living on land a very long time ago. It seems to be closely related to Wailmer.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-55",
@@ -3202,7 +3420,11 @@
       "small": "https://images.pokemontcg.io/sv2/55.png",
       "large": "https://images.pokemontcg.io/sv2/55_hires.png"
     },
-    "flavorText": "This Pokémon wanders around snowy, icy areas. It protects its body with powerful muscles and a thick layer of fat under its skin."
+    "flavorText": "This Pokémon wanders around snowy, icy areas. It protects its body with powerful muscles and a thick layer of fat under its skin.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-56",
@@ -3265,7 +3487,11 @@
       "small": "https://images.pokemontcg.io/sv2/56.png",
       "large": "https://images.pokemontcg.io/sv2/56_hires.png"
     },
-    "flavorText": "When Veluza discards unnecessary flesh, its mind becomes honed and its psychic power increases. The spare flesh has a mild but delicious flavor."
+    "flavorText": "When Veluza discards unnecessary flesh, its mind becomes honed and its psychic power increases. The spare flesh has a mild but delicious flavor.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-57",
@@ -3316,7 +3542,11 @@
       "small": "https://images.pokemontcg.io/sv2/57.png",
       "large": "https://images.pokemontcg.io/sv2/57_hires.png"
     },
-    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores."
+    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-58",
@@ -3378,7 +3608,11 @@
       "small": "https://images.pokemontcg.io/sv2/58.png",
       "large": "https://images.pokemontcg.io/sv2/58_hires.png"
     },
-    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores."
+    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-59",
@@ -3442,7 +3676,11 @@
       "small": "https://images.pokemontcg.io/sv2/59.png",
       "large": "https://images.pokemontcg.io/sv2/59_hires.png"
     },
-    "flavorText": "Arctibax freezes the air around it, protecting its face with an ice mask and turning its dorsal fin into a blade of ice."
+    "flavorText": "Arctibax freezes the air around it, protecting its face with an ice mask and turning its dorsal fin into a blade of ice.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-60",
@@ -3503,7 +3741,14 @@
       "small": "https://images.pokemontcg.io/sv2/60.png",
       "large": "https://images.pokemontcg.io/sv2/60_hires.png"
     },
-    "flavorText": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava."
+    "flavorText": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-61",
@@ -3565,7 +3810,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/61.png",
       "large": "https://images.pokemontcg.io/sv2/61_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-62",
@@ -3625,7 +3875,12 @@
       "small": "https://images.pokemontcg.io/sv2/62.png",
       "large": "https://images.pokemontcg.io/sv2/62_hires.png"
     },
-    "flavorText": "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks."
+    "flavorText": "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv2-63",
@@ -3685,7 +3940,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/63.png",
       "large": "https://images.pokemontcg.io/sv2/63_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-64",
@@ -3747,7 +4005,11 @@
       "small": "https://images.pokemontcg.io/sv2/64.png",
       "large": "https://images.pokemontcg.io/sv2/64_hires.png"
     },
-    "flavorText": "Its tail discharges electricity into the ground, protecting it from getting shocked."
+    "flavorText": "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-65",
@@ -3807,7 +4069,11 @@
       "small": "https://images.pokemontcg.io/sv2/65.png",
       "large": "https://images.pokemontcg.io/sv2/65_hires.png"
     },
-    "flavorText": "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float."
+    "flavorText": "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-66",
@@ -3867,7 +4133,12 @@
       "small": "https://images.pokemontcg.io/sv2/66.png",
       "large": "https://images.pokemontcg.io/sv2/66_hires.png"
     },
-    "flavorText": "It rolls to move. If the ground is uneven, a sudden jolt from hitting a bump can cause it to explode."
+    "flavorText": "It rolls to move. If the ground is uneven, a sudden jolt from hitting a bump can cause it to explode.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Professor Program"
+    ]
   },
   {
     "id": "sv2-67",
@@ -3929,7 +4200,11 @@
       "small": "https://images.pokemontcg.io/sv2/67.png",
       "large": "https://images.pokemontcg.io/sv2/67_hires.png"
     },
-    "flavorText": "The more energy it charges up, the faster it gets. But this also makes it more likely to explode."
+    "flavorText": "The more energy it charges up, the faster it gets. But this also makes it more likely to explode.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-68",
@@ -3986,7 +4261,11 @@
       "small": "https://images.pokemontcg.io/sv2/68.png",
       "large": "https://images.pokemontcg.io/sv2/68_hires.png"
     },
-    "flavorText": "The extension and contraction of its muscles generates electricity. It glows when in trouble."
+    "flavorText": "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-69",
@@ -4036,7 +4315,11 @@
       "small": "https://images.pokemontcg.io/sv2/69.png",
       "large": "https://images.pokemontcg.io/sv2/69_hires.png"
     },
-    "flavorText": "The extension and contraction of its muscles generates electricity. It glows when in trouble."
+    "flavorText": "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-70",
@@ -4098,7 +4381,11 @@
       "small": "https://images.pokemontcg.io/sv2/70.png",
       "large": "https://images.pokemontcg.io/sv2/70_hires.png"
     },
-    "flavorText": "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes."
+    "flavorText": "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-71",
@@ -4158,7 +4445,13 @@
       "small": "https://images.pokemontcg.io/sv2/71.png",
       "large": "https://images.pokemontcg.io/sv2/71_hires.png"
     },
-    "flavorText": "It can see clearly through walls to track down its prey and seek its lost young."
+    "flavorText": "It can see clearly through walls to track down its prey and seek its lost young.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-72",
@@ -4211,7 +4504,11 @@
       "small": "https://images.pokemontcg.io/sv2/72.png",
       "large": "https://images.pokemontcg.io/sv2/72_hires.png"
     },
-    "flavorText": "This Pokémon generates electricity when it digests food. It uses its five hard teeth to scrape seaweed off surfaces and eat it."
+    "flavorText": "This Pokémon generates electricity when it digests food. It uses its five hard teeth to scrape seaweed off surfaces and eat it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-73",
@@ -4272,7 +4569,11 @@
       "small": "https://images.pokemontcg.io/sv2/73.png",
       "large": "https://images.pokemontcg.io/sv2/73_hires.png"
     },
-    "flavorText": "This Pokémon generates electricity when it digests food. It uses its five hard teeth to scrape seaweed off surfaces and eat it."
+    "flavorText": "This Pokémon generates electricity when it digests food. It uses its five hard teeth to scrape seaweed off surfaces and eat it.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-74",
@@ -4322,7 +4623,12 @@
       "small": "https://images.pokemontcg.io/sv2/74.png",
       "large": "https://images.pokemontcg.io/sv2/74_hires.png"
     },
-    "flavorText": "It has underdeveloped electric sacs on its cheeks. These sacs can produce electricity only if Pawmi rubs them furiously with the pads on its forepaws."
+    "flavorText": "It has underdeveloped electric sacs on its cheeks. These sacs can produce electricity only if Pawmi rubs them furiously with the pads on its forepaws.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-75",
@@ -4383,7 +4689,12 @@
       "small": "https://images.pokemontcg.io/sv2/75.png",
       "large": "https://images.pokemontcg.io/sv2/75_hires.png"
     },
-    "flavorText": "When its group is attacked, Pawmo is the first to leap into battle, defeating enemies with a fighting technique that utilizes electric shocks."
+    "flavorText": "When its group is attacked, Pawmo is the first to leap into battle, defeating enemies with a fighting technique that utilizes electric shocks.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-76",
@@ -4444,7 +4755,11 @@
       "small": "https://images.pokemontcg.io/sv2/76.png",
       "large": "https://images.pokemontcg.io/sv2/76_hires.png"
     },
-    "flavorText": "This Pokémon normally is slow to react, but once it enters battle, it will strike down its enemies with lightning-fast movements."
+    "flavorText": "This Pokémon normally is slow to react, but once it enters battle, it will strike down its enemies with lightning-fast movements.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-77",
@@ -4494,7 +4809,11 @@
       "small": "https://images.pokemontcg.io/sv2/77.png",
       "large": "https://images.pokemontcg.io/sv2/77_hires.png"
     },
-    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies."
+    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-78",
@@ -4554,7 +4873,11 @@
       "small": "https://images.pokemontcg.io/sv2/78.png",
       "large": "https://images.pokemontcg.io/sv2/78_hires.png"
     },
-    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies."
+    "flavorText": "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-79",
@@ -4622,7 +4945,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/79.png",
       "large": "https://images.pokemontcg.io/sv2/79_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-80",
@@ -4688,7 +5014,11 @@
       "small": "https://images.pokemontcg.io/sv2/80.png",
       "large": "https://images.pokemontcg.io/sv2/80_hires.png"
     },
-    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them."
+    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-81",
@@ -4755,7 +5085,11 @@
       "small": "https://images.pokemontcg.io/sv2/81.png",
       "large": "https://images.pokemontcg.io/sv2/81_hires.png"
     },
-    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them."
+    "flavorText": "When its wings catch the wind, the bones within produce electricity. This Pokémon dives into the ocean, catching prey by electrocuting them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-82",
@@ -4819,7 +5153,11 @@
       "small": "https://images.pokemontcg.io/sv2/82.png",
       "large": "https://images.pokemontcg.io/sv2/82_hires.png"
     },
-    "flavorText": "Kilowattrel inflates its throat sac to amplify its electricity. By riding the wind, this Pokémon can fly over 430 miles in a day."
+    "flavorText": "Kilowattrel inflates its throat sac to amplify its electricity. By riding the wind, this Pokémon can fly over 430 miles in a day.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-83",
@@ -4879,7 +5217,11 @@
       "small": "https://images.pokemontcg.io/sv2/83.png",
       "large": "https://images.pokemontcg.io/sv2/83_hires.png"
     },
-    "flavorText": "When its huge eyes waver, it sings a mysteriously soothing melody that lulls its enemies to sleep."
+    "flavorText": "When its huge eyes waver, it sings a mysteriously soothing melody that lulls its enemies to sleep.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-84",
@@ -4940,7 +5282,11 @@
       "small": "https://images.pokemontcg.io/sv2/84.png",
       "large": "https://images.pokemontcg.io/sv2/84_hires.png"
     },
-    "flavorText": "It has a very fine fur. Take care not to make it angry, or it may inflate steadily and hit with a body slam."
+    "flavorText": "It has a very fine fur. Take care not to make it angry, or it may inflate steadily and hit with a body slam.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-85",
@@ -5008,7 +5354,11 @@
       "small": "https://images.pokemontcg.io/sv2/85.png",
       "large": "https://images.pokemontcg.io/sv2/85_hires.png"
     },
-    "flavorText": "It is incredibly slow and dopey. It takes five seconds for it to feel pain when under attack."
+    "flavorText": "It is incredibly slow and dopey. It takes five seconds for it to feel pain when under attack.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-86",
@@ -5082,7 +5432,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/86.png",
       "large": "https://images.pokemontcg.io/sv2/86_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-87",
@@ -5139,7 +5492,11 @@
       "small": "https://images.pokemontcg.io/sv2/87.png",
       "large": "https://images.pokemontcg.io/sv2/87_hires.png"
     },
-    "flavorText": "This Pokémon startles people in the middle of the night. It gathers fear as its energy."
+    "flavorText": "This Pokémon startles people in the middle of the night. It gathers fear as its energy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-88",
@@ -5204,7 +5561,12 @@
       "small": "https://images.pokemontcg.io/sv2/88.png",
       "large": "https://images.pokemontcg.io/sv2/88_hires.png"
     },
-    "flavorText": "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power."
+    "flavorText": "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv2-89",
@@ -5267,7 +5629,12 @@
       "small": "https://images.pokemontcg.io/sv2/89.png",
       "large": "https://images.pokemontcg.io/sv2/89_hires.png"
     },
-    "flavorText": "Its constant mischief and misdeeds resulted in it being bound to an Odd Keystone by a mysterious spell."
+    "flavorText": "Its constant mischief and misdeeds resulted in it being bound to an Odd Keystone by a mysterious spell.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-90",
@@ -5333,7 +5700,11 @@
       "small": "https://images.pokemontcg.io/sv2/90.png",
       "large": "https://images.pokemontcg.io/sv2/90_hires.png"
     },
-    "flavorText": "This Pokémon is normally very innocent. When it is staring at something invisible, it is unblinking and utterly silent."
+    "flavorText": "This Pokémon is normally very innocent. When it is staring at something invisible, it is unblinking and utterly silent.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-91",
@@ -5400,7 +5771,11 @@
       "small": "https://images.pokemontcg.io/sv2/91.png",
       "large": "https://images.pokemontcg.io/sv2/91_hires.png"
     },
-    "flavorText": "This Pokémon will hypnotize children to put them to sleep before carrying them away. Be wary of nights when the starlight is bright."
+    "flavorText": "This Pokémon will hypnotize children to put them to sleep before carrying them away. Be wary of nights when the starlight is bright.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-92",
@@ -5466,7 +5841,11 @@
       "small": "https://images.pokemontcg.io/sv2/92.png",
       "large": "https://images.pokemontcg.io/sv2/92_hires.png"
     },
-    "flavorText": "Gothitelle unleashes psychic energy and shows opponents dreams of the universe's end. These dreams are apparently ethereal and beautiful."
+    "flavorText": "Gothitelle unleashes psychic energy and shows opponents dreams of the universe's end. These dreams are apparently ethereal and beautiful.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-93",
@@ -5533,7 +5912,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/93.png",
       "large": "https://images.pokemontcg.io/sv2/93_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-94",
@@ -5602,7 +5985,11 @@
       "small": "https://images.pokemontcg.io/sv2/94.png",
       "large": "https://images.pokemontcg.io/sv2/94_hires.png"
     },
-    "flavorText": "People used to mistake Oranguru for a human when they saw it issue command after command to the other Pokémon of the forest."
+    "flavorText": "People used to mistake Oranguru for a human when they saw it issue command after command to the other Pokémon of the forest.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-95",
@@ -5672,7 +6059,11 @@
       "small": "https://images.pokemontcg.io/sv2/95.png",
       "large": "https://images.pokemontcg.io/sv2/95_hires.png"
     },
-    "flavorText": "If it loses its shovel, it will stick something else— like a branch—in its head to make do until it finds another shovel."
+    "flavorText": "If it loses its shovel, it will stick something else— like a branch—in its head to make do until it finds another shovel.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-96",
@@ -5744,7 +6135,11 @@
       "small": "https://images.pokemontcg.io/sv2/96.png",
       "large": "https://images.pokemontcg.io/sv2/96_hires.png"
     },
-    "flavorText": "The terrifying Palossand drags smaller Pokémon into its sandy body. Once its victims are trapped, it drains them of their vitality whenever it pleases."
+    "flavorText": "The terrifying Palossand drags smaller Pokémon into its sandy body. Once its victims are trapped, it drains them of their vitality whenever it pleases.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-97",
@@ -5802,7 +6197,13 @@
       "small": "https://images.pokemontcg.io/sv2/97.png",
       "large": "https://images.pokemontcg.io/sv2/97_hires.png"
     },
-    "flavorText": "This Pokémon lives in dark places untouched by sunlight. When it appears before humans, it hides itself under a cloth that resembles a Pikachu."
+    "flavorText": "This Pokémon lives in dark places untouched by sunlight. When it appears before humans, it hides itself under a cloth that resembles a Pikachu.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv2-98",
@@ -5872,7 +6273,12 @@
       "small": "https://images.pokemontcg.io/sv2/98.png",
       "large": "https://images.pokemontcg.io/sv2/98_hires.png"
     },
-    "flavorText": "The fiery blades on its arms burn fiercely with the lingering resentment of a sword wielder who fell before accomplishing their goal."
+    "flavorText": "The fiery blades on its arms burn fiercely with the lingering resentment of a sword wielder who fell before accomplishing their goal.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-99",
@@ -5939,7 +6345,11 @@
       "small": "https://images.pokemontcg.io/sv2/99.png",
       "large": "https://images.pokemontcg.io/sv2/99_hires.png"
     },
-    "flavorText": "The body that supports the ball barely moves. Therefore, it is thought that the true body of this Pokémon is actually inside the ball."
+    "flavorText": "The body that supports the ball barely moves. Therefore, it is thought that the true body of this Pokémon is actually inside the ball.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-100",
@@ -5999,7 +6409,11 @@
       "small": "https://images.pokemontcg.io/sv2/100.png",
       "large": "https://images.pokemontcg.io/sv2/100_hires.png"
     },
-    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
+    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-101",
@@ -6060,7 +6474,11 @@
       "small": "https://images.pokemontcg.io/sv2/101.png",
       "large": "https://images.pokemontcg.io/sv2/101_hires.png"
     },
-    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
+    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-102",
@@ -6110,7 +6528,11 @@
       "small": "https://images.pokemontcg.io/sv2/102.png",
       "large": "https://images.pokemontcg.io/sv2/102_hires.png"
     },
-    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
+    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-103",
@@ -6172,7 +6594,11 @@
       "small": "https://images.pokemontcg.io/sv2/103.png",
       "large": "https://images.pokemontcg.io/sv2/103_hires.png"
     },
-    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer."
+    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-104",
@@ -6236,7 +6662,11 @@
       "small": "https://images.pokemontcg.io/sv2/104.png",
       "large": "https://images.pokemontcg.io/sv2/104_hires.png"
     },
-    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer."
+    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-105",
@@ -6296,7 +6726,15 @@
       "small": "https://images.pokemontcg.io/sv2/105.png",
       "large": "https://images.pokemontcg.io/sv2/105_hires.png"
     },
-    "flavorText": "This intelligent Pokémon has a very daring disposition. It knocks rocks into the sky with its hammer, aiming for flying Corviknight."
+    "flavorText": "This intelligent Pokémon has a very daring disposition. It knocks rocks into the sky with its hammer, aiming for flying Corviknight.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "GameStop",
+      "Normal",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv2-106",
@@ -6356,7 +6794,12 @@
       "small": "https://images.pokemontcg.io/sv2/106.png",
       "large": "https://images.pokemontcg.io/sv2/106_hires.png"
     },
-    "flavorText": "It lives in groups in the treetops. If it loses sight of its group, it becomes infuriated by its loneliness."
+    "flavorText": "It lives in groups in the treetops. If it loses sight of its group, it becomes infuriated by its loneliness.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-107",
@@ -6418,7 +6861,12 @@
       "small": "https://images.pokemontcg.io/sv2/107.png",
       "large": "https://images.pokemontcg.io/sv2/107_hires.png"
     },
-    "flavorText": "It becomes wildly furious if it even senses someone looking at it. It chases anyone that meets its glare."
+    "flavorText": "It becomes wildly furious if it even senses someone looking at it. It chases anyone that meets its glare.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-108",
@@ -6481,7 +6929,11 @@
       "small": "https://images.pokemontcg.io/sv2/108.png",
       "large": "https://images.pokemontcg.io/sv2/108_hires.png"
     },
-    "flavorText": "This kind of Tauros, known as the Combat Breed, is distinguished by its thick, powerful muscles and its fierce disposition."
+    "flavorText": "This kind of Tauros, known as the Combat Breed, is distinguished by its thick, powerful muscles and its fierce disposition.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-109",
@@ -6542,7 +6994,11 @@
       "small": "https://images.pokemontcg.io/sv2/109.png",
       "large": "https://images.pokemontcg.io/sv2/109_hires.png"
     },
-    "flavorText": "Although it always pretends to be a tree, its composition appears more similar to rock than to vegetation."
+    "flavorText": "Although it always pretends to be a tree, its composition appears more similar to rock than to vegetation.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-110",
@@ -6593,7 +7049,12 @@
       "small": "https://images.pokemontcg.io/sv2/110.png",
       "large": "https://images.pokemontcg.io/sv2/110_hires.png"
     },
-    "flavorText": "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain."
+    "flavorText": "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-111",
@@ -6645,7 +7106,12 @@
       "small": "https://images.pokemontcg.io/sv2/111.png",
       "large": "https://images.pokemontcg.io/sv2/111_hires.png"
     },
-    "flavorText": "This pupa flies around wildly by venting with great force the gas pressurized inside its body."
+    "flavorText": "This pupa flies around wildly by venting with great force the gas pressurized inside its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-112",
@@ -6698,7 +7164,11 @@
       "small": "https://images.pokemontcg.io/sv2/112.png",
       "large": "https://images.pokemontcg.io/sv2/112_hires.png"
     },
-    "flavorText": "It grows stronger by enduring harsh training. It is a gutsy Pokémon that can withstand any attack."
+    "flavorText": "It grows stronger by enduring harsh training. It is a gutsy Pokémon that can withstand any attack.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-113",
@@ -6760,7 +7230,11 @@
       "small": "https://images.pokemontcg.io/sv2/113.png",
       "large": "https://images.pokemontcg.io/sv2/113_hires.png"
     },
-    "flavorText": "It loves challenging others to tests of strength. It has the power to stop a train with a slap."
+    "flavorText": "It loves challenging others to tests of strength. It has the power to stop a train with a slap.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-114",
@@ -6810,7 +7284,11 @@
       "small": "https://images.pokemontcg.io/sv2/114.png",
       "large": "https://images.pokemontcg.io/sv2/114_hires.png"
     },
-    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab."
+    "flavorText": "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-115",
@@ -6871,7 +7349,11 @@
       "small": "https://images.pokemontcg.io/sv2/115.png",
       "large": "https://images.pokemontcg.io/sv2/115_hires.png"
     },
-    "flavorText": "Swaying and dodging the attacks of its foes, it weaves its flexible body in close, then lunges out with its poisonous claws."
+    "flavorText": "Swaying and dodging the attacks of its foes, it weaves its flexible body in close, then lunges out with its poisonous claws.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-116",
@@ -6932,7 +7414,11 @@
       "small": "https://images.pokemontcg.io/sv2/116.png",
       "large": "https://images.pokemontcg.io/sv2/116_hires.png"
     },
-    "flavorText": "This Pokémon is very friendly when it's young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master."
+    "flavorText": "This Pokémon is very friendly when it's young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-117",
@@ -6998,7 +7484,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/117.png",
       "large": "https://images.pokemontcg.io/sv2/117_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-118",
@@ -7049,7 +7538,11 @@
       "small": "https://images.pokemontcg.io/sv2/118.png",
       "large": "https://images.pokemontcg.io/sv2/118_hires.png"
     },
-    "flavorText": "This Pokémon battles by throwing hard berries. It won't obey a Trainer who throws Poké Balls without skill."
+    "flavorText": "This Pokémon battles by throwing hard berries. It won't obey a Trainer who throws Poké Balls without skill.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-119",
@@ -7111,7 +7604,11 @@
       "small": "https://images.pokemontcg.io/sv2/119.png",
       "large": "https://images.pokemontcg.io/sv2/119_hires.png"
     },
-    "flavorText": "The brass, which is the one that stands at the front and issues orders, is the strongest and smartest of the six."
+    "flavorText": "The brass, which is the one that stands at the front and issues orders, is the strongest and smartest of the six.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-120",
@@ -7162,7 +7659,11 @@
       "small": "https://images.pokemontcg.io/sv2/120.png",
       "large": "https://images.pokemontcg.io/sv2/120_hires.png"
     },
-    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt."
+    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-121",
@@ -7224,7 +7725,11 @@
       "small": "https://images.pokemontcg.io/sv2/121.png",
       "large": "https://images.pokemontcg.io/sv2/121_hires.png"
     },
-    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt."
+    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-122",
@@ -7278,7 +7783,11 @@
       "small": "https://images.pokemontcg.io/sv2/122.png",
       "large": "https://images.pokemontcg.io/sv2/122_hires.png"
     },
-    "flavorText": "This Pokémon dry cures its prey by spraying salt over them. The curing process steals away the water in the prey's body."
+    "flavorText": "This Pokémon dry cures its prey by spraying salt over them. The curing process steals away the water in the prey's body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-123",
@@ -7339,7 +7848,12 @@
       "small": "https://images.pokemontcg.io/sv2/123.png",
       "large": "https://images.pokemontcg.io/sv2/123_hires.png"
     },
-    "flavorText": "Garganacl will rub its fingertips together and sprinkle injured Pokémon with salt. Even severe wounds will promptly heal afterward."
+    "flavorText": "Garganacl will rub its fingertips together and sprinkle injured Pokémon with salt. Even severe wounds will promptly heal afterward.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-124",
@@ -7389,7 +7903,11 @@
       "small": "https://images.pokemontcg.io/sv2/124.png",
       "large": "https://images.pokemontcg.io/sv2/124_hires.png"
     },
-    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison."
+    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-125",
@@ -7440,7 +7958,11 @@
       "small": "https://images.pokemontcg.io/sv2/125.png",
       "large": "https://images.pokemontcg.io/sv2/125_hires.png"
     },
-    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison."
+    "flavorText": "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-126",
@@ -7500,7 +8022,12 @@
       "small": "https://images.pokemontcg.io/sv2/126.png",
       "large": "https://images.pokemontcg.io/sv2/126_hires.png"
     },
-    "flavorText": "When this Pokémon detects danger, it will open up its crystalline petals and fire beams from its conical body."
+    "flavorText": "When this Pokémon detects danger, it will open up its crystalline petals and fire beams from its conical body.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-127",
@@ -7565,7 +8092,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/127.png",
       "large": "https://images.pokemontcg.io/sv2/127_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-128",
@@ -7625,7 +8156,11 @@
       "small": "https://images.pokemontcg.io/sv2/128.png",
       "large": "https://images.pokemontcg.io/sv2/128_hires.png"
     },
-    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body."
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-129",
@@ -7685,7 +8220,11 @@
       "small": "https://images.pokemontcg.io/sv2/129.png",
       "large": "https://images.pokemontcg.io/sv2/129_hires.png"
     },
-    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body."
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-130",
@@ -7750,7 +8289,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/130.png",
       "large": "https://images.pokemontcg.io/sv2/130_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-131",
@@ -7815,7 +8357,12 @@
       "small": "https://images.pokemontcg.io/sv2/131.png",
       "large": "https://images.pokemontcg.io/sv2/131_hires.png"
     },
-    "flavorText": "Feared and loathed by many, it is believed to bring misfortune to all those who see it at night."
+    "flavorText": "Feared and loathed by many, it is believed to bring misfortune to all those who see it at night.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Trick or Trade 2023"
+    ]
   },
   {
     "id": "sv2-132",
@@ -7883,7 +8430,11 @@
       "small": "https://images.pokemontcg.io/sv2/132.png",
       "large": "https://images.pokemontcg.io/sv2/132_hires.png"
     },
-    "flavorText": "It is merciless by nature. It is said that it never forgives the mistakes of its Murkrow followers."
+    "flavorText": "It is merciless by nature. It is said that it never forgives the mistakes of its Murkrow followers.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-133",
@@ -7933,7 +8484,11 @@
       "small": "https://images.pokemontcg.io/sv2/133.png",
       "large": "https://images.pokemontcg.io/sv2/133_hires.png"
     },
-    "flavorText": "This cunning Pokémon hides under the cover of darkness, waiting to attack its prey."
+    "flavorText": "This cunning Pokémon hides under the cover of darkness, waiting to attack its prey.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-134",
@@ -7992,7 +8547,11 @@
       "small": "https://images.pokemontcg.io/sv2/134.png",
       "large": "https://images.pokemontcg.io/sv2/134_hires.png"
     },
-    "flavorText": "Evolution made it even more devious. It communicates by clawing signs in boulders."
+    "flavorText": "Evolution made it even more devious. It communicates by clawing signs in boulders.",
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-135",
@@ -8055,7 +8614,12 @@
       "small": "https://images.pokemontcg.io/sv2/135.png",
       "large": "https://images.pokemontcg.io/sv2/135_hires.png"
     },
-    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others."
+    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-136",
@@ -8114,7 +8678,12 @@
       "small": "https://images.pokemontcg.io/sv2/136.png",
       "large": "https://images.pokemontcg.io/sv2/136_hires.png"
     },
-    "flavorText": "It dwells in the darkness of caves. It uses its sharp claws to dig up gems to nourish itself."
+    "flavorText": "It dwells in the darkness of caves. It uses its sharp claws to dig up gems to nourish itself.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-137",
@@ -8174,7 +8743,11 @@
       "small": "https://images.pokemontcg.io/sv2/137.png",
       "large": "https://images.pokemontcg.io/sv2/137_hires.png"
     },
-    "flavorText": "It sharpens its swordlike tail on hard rocks. It hides in tall grass and strikes unwary prey with venomous fangs."
+    "flavorText": "It sharpens its swordlike tail on hard rocks. It hides in tall grass and strikes unwary prey with venomous fangs.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-138",
@@ -8225,7 +8798,11 @@
       "small": "https://images.pokemontcg.io/sv2/138.png",
       "large": "https://images.pokemontcg.io/sv2/138_hires.png"
     },
-    "flavorText": "It can't see, so its first approach to examining things is to bite them. You will be covered in wounds until a Deino warms up to you."
+    "flavorText": "It can't see, so its first approach to examining things is to bite them. You will be covered in wounds until a Deino warms up to you.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-139",
@@ -8288,7 +8865,11 @@
       "small": "https://images.pokemontcg.io/sv2/139.png",
       "large": "https://images.pokemontcg.io/sv2/139_hires.png"
     },
-    "flavorText": "The two heads do not get along at all. If you don't give each head the same amount of attention, they'll begin fighting out of jealousy."
+    "flavorText": "The two heads do not get along at all. If you don't give each head the same amount of attention, they'll begin fighting out of jealousy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-140",
@@ -8350,7 +8931,12 @@
       "small": "https://images.pokemontcg.io/sv2/140.png",
       "large": "https://images.pokemontcg.io/sv2/140_hires.png"
     },
-    "flavorText": "Only the central head has a brain. It is very intelligent, but it thinks only of destruction."
+    "flavorText": "Only the central head has a brain. It is very intelligent, but it thinks only of destruction.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-141",
@@ -8400,7 +8986,11 @@
       "small": "https://images.pokemontcg.io/sv2/141.png",
       "large": "https://images.pokemontcg.io/sv2/141_hires.png"
     },
-    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face."
+    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-142",
@@ -8463,7 +9053,12 @@
       "small": "https://images.pokemontcg.io/sv2/142.png",
       "large": "https://images.pokemontcg.io/sv2/142_hires.png"
     },
-    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face."
+    "flavorText": "It always scowls in an attempt to make opponents take it seriously, but even crying children will burst into laughter when they see Maschiff's face.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-143",
@@ -8528,7 +9123,11 @@
       "small": "https://images.pokemontcg.io/sv2/143.png",
       "large": "https://images.pokemontcg.io/sv2/143_hires.png"
     },
-    "flavorText": "This Pokémon can store energy in its large dewlap. Mabosstiff unleashes this energy all at once to blow away enemies."
+    "flavorText": "This Pokémon can store energy in its large dewlap. Mabosstiff unleashes this energy all at once to blow away enemies.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-144",
@@ -8587,7 +9186,11 @@
       "small": "https://images.pokemontcg.io/sv2/144.png",
       "large": "https://images.pokemontcg.io/sv2/144_hires.png"
     },
-    "flavorText": "Though usually a mellow Pokémon, it will sink its sharp, poison-soaked front teeth into any that anger it, causing paralysis in the object of its ire."
+    "flavorText": "Though usually a mellow Pokémon, it will sink its sharp, poison-soaked front teeth into any that anger it, causing paralysis in the object of its ire.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-145",
@@ -8637,7 +9240,11 @@
       "small": "https://images.pokemontcg.io/sv2/145.png",
       "large": "https://images.pokemontcg.io/sv2/145_hires.png"
     },
-    "flavorText": "Though usually a mellow Pokémon, it will sink its sharp, poison-soaked front teeth into any that anger it, causing paralysis in the object of its ire."
+    "flavorText": "Though usually a mellow Pokémon, it will sink its sharp, poison-soaked front teeth into any that anger it, causing paralysis in the object of its ire.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-146",
@@ -8697,7 +9304,11 @@
       "small": "https://images.pokemontcg.io/sv2/146.png",
       "large": "https://images.pokemontcg.io/sv2/146_hires.png"
     },
-    "flavorText": "The color of the poisonous saliva depends on what the Pokémon eats. Grafaiai covers its fingers in its saliva and draws patterns on trees in forests."
+    "flavorText": "The color of the poisonous saliva depends on what the Pokémon eats. Grafaiai covers its fingers in its saliva and draws patterns on trees in forests.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-147",
@@ -8764,7 +9375,11 @@
       "small": "https://images.pokemontcg.io/sv2/147.png",
       "large": "https://images.pokemontcg.io/sv2/147_hires.png"
     },
-    "flavorText": "It gathers things up in an apron made from shed feathers added to the Pokémon's chest feathers, then drops those things from high places for fun."
+    "flavorText": "It gathers things up in an apron made from shed feathers added to the Pokémon's chest feathers, then drops those things from high places for fun.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-148",
@@ -8833,7 +9448,11 @@
       "small": "https://images.pokemontcg.io/sv2/148.png",
       "large": "https://images.pokemontcg.io/sv2/148_hires.png"
     },
-    "flavorText": "Corviknight can't serve as a taxi service in Paldea because the Pokémon's natural predators will attack it while it flies, endangering the customer."
+    "flavorText": "Corviknight can't serve as a taxi service in Paldea because the Pokémon's natural predators will attack it while it flies, endangering the customer.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-149",
@@ -8892,7 +9511,11 @@
       "small": "https://images.pokemontcg.io/sv2/149.png",
       "large": "https://images.pokemontcg.io/sv2/149_hires.png"
     },
-    "flavorText": "Using the pointy tip of its trunk, it carves off chunks of hard rocks to eat. It is very docile and helps people with physical labor."
+    "flavorText": "Using the pointy tip of its trunk, it carves off chunks of hard rocks to eat. It is very docile and helps people with physical labor.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-150",
@@ -8964,7 +9587,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/150.png",
       "large": "https://images.pokemontcg.io/sv2/150_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-151",
@@ -9031,7 +9657,13 @@
       "small": "https://images.pokemontcg.io/sv2/151.png",
       "large": "https://images.pokemontcg.io/sv2/151_hires.png"
     },
-    "flavorText": "When attacked, this Pokémon will wield the tendrils on its body like fists and pelt the opponent with a storm of punches."
+    "flavorText": "When attacked, this Pokémon will wield the tendrils on its body like fists and pelt the opponent with a storm of punches.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv2-152",
@@ -9076,7 +9708,11 @@
       "small": "https://images.pokemontcg.io/sv2/152.png",
       "large": "https://images.pokemontcg.io/sv2/152_hires.png"
     },
-    "flavorText": "This Pokémon emits ultrasonic waves from its large ears to search for fruit to eat. It mistakes Applin for its food."
+    "flavorText": "This Pokémon emits ultrasonic waves from its large ears to search for fruit to eat. It mistakes Applin for its food.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-153",
@@ -9131,7 +9767,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/153.png",
       "large": "https://images.pokemontcg.io/sv2/153_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-154",
@@ -9194,7 +9834,11 @@
       "small": "https://images.pokemontcg.io/sv2/154.png",
       "large": "https://images.pokemontcg.io/sv2/154_hires.png"
     },
-    "flavorText": "Though very small, the brain in its tail is still considered an important organ because it emits powerful psychic energy."
+    "flavorText": "Though very small, the brain in its tail is still considered an important organ because it emits powerful psychic energy.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-155",
@@ -9257,7 +9901,11 @@
       "small": "https://images.pokemontcg.io/sv2/155.png",
       "large": "https://images.pokemontcg.io/sv2/155_hires.png"
     },
-    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's."
+    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-156",
@@ -9318,7 +9966,11 @@
       "small": "https://images.pokemontcg.io/sv2/156.png",
       "large": "https://images.pokemontcg.io/sv2/156_hires.png"
     },
-    "flavorText": "It creates mazes in dark locations. When spotted, it flees into the ground by digging with its tail."
+    "flavorText": "It creates mazes in dark locations. When spotted, it flees into the ground by digging with its tail.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-157",
@@ -9383,7 +10035,11 @@
       "small": "https://images.pokemontcg.io/sv2/157.png",
       "large": "https://images.pokemontcg.io/sv2/157_hires.png"
     },
-    "flavorText": "This Pokémon uses its hard tail to make its nest by boring holes into bedrock deep underground. The nest can reach lengths of over six miles."
+    "flavorText": "This Pokémon uses its hard tail to make its nest by boring holes into bedrock deep underground. The nest can reach lengths of over six miles.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-158",
@@ -9440,7 +10096,11 @@
       "small": "https://images.pokemontcg.io/sv2/158.png",
       "large": "https://images.pokemontcg.io/sv2/158_hires.png"
     },
-    "flavorText": "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill."
+    "flavorText": "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-159",
@@ -9507,7 +10167,12 @@
       "small": "https://images.pokemontcg.io/sv2/159.png",
       "large": "https://images.pokemontcg.io/sv2/159_hires.png"
     },
-    "flavorText": "It is a flying transporter that carries small Pokémon in its beak. It bobs on the waves to rest its wings."
+    "flavorText": "It is a flying transporter that carries small Pokémon in its beak. It bobs on the waves to rest its wings.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-160",
@@ -9559,7 +10224,12 @@
       "small": "https://images.pokemontcg.io/sv2/160.png",
       "large": "https://images.pokemontcg.io/sv2/160_hires.png"
     },
-    "flavorText": "It sleeps for 20 hours every day. Making drowsy those that see it is one of its abilities."
+    "flavorText": "It sleeps for 20 hours every day. Making drowsy those that see it is one of its abilities.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-161",
@@ -9623,7 +10293,12 @@
       "small": "https://images.pokemontcg.io/sv2/161.png",
       "large": "https://images.pokemontcg.io/sv2/161_hires.png"
     },
-    "flavorText": "Its stress level rises if it cannot keep moving constantly. Too much stress makes it feel sick."
+    "flavorText": "Its stress level rises if it cannot keep moving constantly. Too much stress makes it feel sick.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-162",
@@ -9686,7 +10361,12 @@
       "small": "https://images.pokemontcg.io/sv2/162.png",
       "large": "https://images.pokemontcg.io/sv2/162_hires.png"
     },
-    "flavorText": "It is the world's most slothful Pokémon. However, it can exert horrifying power by releasing pent-up energy all at once."
+    "flavorText": "It is the world's most slothful Pokémon. However, it can exert horrifying power by releasing pent-up energy all at once.",
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-163",
@@ -9742,7 +10422,11 @@
       "small": "https://images.pokemontcg.io/sv2/163.png",
       "large": "https://images.pokemontcg.io/sv2/163_hires.png"
     },
-    "flavorText": "This Pokémon is normally calm, but once it enters battle, its hormonal balance changes and it becomes aggressive."
+    "flavorText": "This Pokémon is normally calm, but once it enters battle, its hormonal balance changes and it becomes aggressive.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-164",
@@ -9798,7 +10482,11 @@
       "small": "https://images.pokemontcg.io/sv2/164.png",
       "large": "https://images.pokemontcg.io/sv2/164_hires.png"
     },
-    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon."
+    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-165",
@@ -9866,7 +10554,11 @@
       "small": "https://images.pokemontcg.io/sv2/165.png",
       "large": "https://images.pokemontcg.io/sv2/165_hires.png"
     },
-    "flavorText": "It's said that the reason behind Corvisquire's high level of intelligence is the large size of its brain relative to those of other bird Pokémon."
+    "flavorText": "It's said that the reason behind Corvisquire's high level of intelligence is the large size of its brain relative to those of other bird Pokémon.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-166",
@@ -9927,7 +10619,11 @@
       "small": "https://images.pokemontcg.io/sv2/166.png",
       "large": "https://images.pokemontcg.io/sv2/166_hires.png"
     },
-    "flavorText": "Exhibiting great teamwork, they use their incisors to cut pieces out of any material that might be useful for a nest, then make off with them."
+    "flavorText": "Exhibiting great teamwork, they use their incisors to cut pieces out of any material that might be useful for a nest, then make off with them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-167",
@@ -9987,7 +10683,12 @@
       "small": "https://images.pokemontcg.io/sv2/167.png",
       "large": "https://images.pokemontcg.io/sv2/167_hires.png"
     },
-    "flavorText": "Exhibiting great teamwork, they use their incisors to cut pieces out of any material that might be useful for a nest, then make off with them."
+    "flavorText": "Exhibiting great teamwork, they use their incisors to cut pieces out of any material that might be useful for a nest, then make off with them.",
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-168",
@@ -10050,7 +10751,11 @@
       "small": "https://images.pokemontcg.io/sv2/168.png",
       "large": "https://images.pokemontcg.io/sv2/168_hires.png"
     },
-    "flavorText": "They build huge nests with many rooms that are used for different purposes, such as eating and sleeping."
+    "flavorText": "They build huge nests with many rooms that are used for different purposes, such as eating and sleeping.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-169",
@@ -10116,7 +10821,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/169.png",
       "large": "https://images.pokemontcg.io/sv2/169_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-170",
@@ -10180,7 +10889,11 @@
       "small": "https://images.pokemontcg.io/sv2/170.png",
       "large": "https://images.pokemontcg.io/sv2/170_hires.png"
     },
-    "flavorText": "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak."
+    "flavorText": "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak.",
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-171",
@@ -10205,7 +10918,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/171.png",
       "large": "https://images.pokemontcg.io/sv2/171_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-172",
@@ -10230,7 +10950,15 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/172.png",
       "large": "https://images.pokemontcg.io/sv2/172_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-173",
@@ -10255,7 +10983,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/173.png",
       "large": "https://images.pokemontcg.io/sv2/173_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-174",
@@ -10280,7 +11014,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/174.png",
       "large": "https://images.pokemontcg.io/sv2/174_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-175",
@@ -10305,7 +11043,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/175.png",
       "large": "https://images.pokemontcg.io/sv2/175_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-176",
@@ -10330,7 +11072,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/176.png",
       "large": "https://images.pokemontcg.io/sv2/176_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-177",
@@ -10355,7 +11102,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/177.png",
       "large": "https://images.pokemontcg.io/sv2/177_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo"
+    ]
   },
   {
     "id": "sv2-178",
@@ -10380,7 +11132,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/178.png",
       "large": "https://images.pokemontcg.io/sv2/178_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-179",
@@ -10405,7 +11161,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/179.png",
       "large": "https://images.pokemontcg.io/sv2/179_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-180",
@@ -10430,7 +11190,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/180.png",
       "large": "https://images.pokemontcg.io/sv2/180_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-181",
@@ -10455,7 +11219,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/181.png",
       "large": "https://images.pokemontcg.io/sv2/181_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-182",
@@ -10480,7 +11249,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/182.png",
       "large": "https://images.pokemontcg.io/sv2/182_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-183",
@@ -10505,7 +11278,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/183.png",
       "large": "https://images.pokemontcg.io/sv2/183_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-184",
@@ -10530,7 +11307,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/184.png",
       "large": "https://images.pokemontcg.io/sv2/184_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-185",
@@ -10555,7 +11336,16 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/185.png",
       "large": "https://images.pokemontcg.io/sv2/185_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "Regional Championship",
+      "Regional Championship (Staff)",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-186",
@@ -10580,7 +11370,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/186.png",
       "large": "https://images.pokemontcg.io/sv2/186_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-187",
@@ -10605,7 +11399,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/187.png",
       "large": "https://images.pokemontcg.io/sv2/187_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv2-188",
@@ -10630,7 +11428,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/188.png",
       "large": "https://images.pokemontcg.io/sv2/188_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon",
+      "Play! Pokémon Cosmos Holo",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-189",
@@ -10655,7 +11460,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/189.png",
       "large": "https://images.pokemontcg.io/sv2/189_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-190",
@@ -10681,7 +11492,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/190.png",
       "large": "https://images.pokemontcg.io/sv2/190_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-191",
@@ -10704,7 +11522,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/191.png",
       "large": "https://images.pokemontcg.io/sv2/191_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv2-192",
@@ -10727,7 +11551,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/192.png",
       "large": "https://images.pokemontcg.io/sv2/192_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon Cosmos Holo",
+      "Play! Pokémon",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-193",
@@ -10753,7 +11584,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/193.png",
       "large": "https://images.pokemontcg.io/sv2/193_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "World Championships Deck 2023"
+    ]
   },
   {
     "id": "sv2-194",
@@ -10817,7 +11653,10 @@
       "small": "https://images.pokemontcg.io/sv2/194.png",
       "large": "https://images.pokemontcg.io/sv2/194_hires.png"
     },
-    "flavorText": "It loves sweet nectar. To keep all the nectar to itself, it hurls rivals away with its prized horn."
+    "flavorText": "It loves sweet nectar. To keep all the nectar to itself, it hurls rivals away with its prized horn.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-195",
@@ -10878,7 +11717,10 @@
       "small": "https://images.pokemontcg.io/sv2/195.png",
       "large": "https://images.pokemontcg.io/sv2/195_hires.png"
     },
-    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year."
+    "flavorText": "It lives in tropical jungles. The bunch of fruit around its neck is delicious. The fruit grows twice a year.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-196",
@@ -10937,7 +11779,10 @@
       "small": "https://images.pokemontcg.io/sv2/196.png",
       "large": "https://images.pokemontcg.io/sv2/196_hires.png"
     },
-    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out."
+    "flavorText": "Its fluffy fur is similar in composition to plants. This Pokémon frequently washes its face to keep it from drying out.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-197",
@@ -10998,7 +11843,10 @@
       "small": "https://images.pokemontcg.io/sv2/197.png",
       "large": "https://images.pokemontcg.io/sv2/197_hires.png"
     },
-    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents."
+    "flavorText": "Floragato deftly wields the vine hidden beneath its long fur, slamming the hard flower bud against its opponents.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-198",
@@ -11048,7 +11896,10 @@
       "small": "https://images.pokemontcg.io/sv2/198.png",
       "large": "https://images.pokemontcg.io/sv2/198_hires.png"
     },
-    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon."
+    "flavorText": "A soul unable to move on to the afterlife was blown around by the wind until it got tangled up with dried grass and became a Pokémon.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-199",
@@ -11105,7 +11956,10 @@
       "small": "https://images.pokemontcg.io/sv2/199.png",
       "large": "https://images.pokemontcg.io/sv2/199_hires.png"
     },
-    "flavorText": "Fletchinder scatters embers in tall grass where bug Pokémon might be hiding and then catches them as they come leaping out."
+    "flavorText": "Fletchinder scatters embers in tall grass where bug Pokémon might be hiding and then catches them as they come leaping out.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-200",
@@ -11167,7 +12021,10 @@
       "small": "https://images.pokemontcg.io/sv2/200.png",
       "large": "https://images.pokemontcg.io/sv2/200_hires.png"
     },
-    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve."
+    "flavorText": "The females of a pride work together to bring down prey. It's thanks to them that their pride doesn't starve.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-201",
@@ -11229,7 +12086,10 @@
       "small": "https://images.pokemontcg.io/sv2/201.png",
       "large": "https://images.pokemontcg.io/sv2/201_hires.png"
     },
-    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy."
+    "flavorText": "It lies on warm rocks and uses the heat absorbed by its square-shaped scales to create fire energy.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-202",
@@ -11292,7 +12152,10 @@
       "small": "https://images.pokemontcg.io/sv2/202.png",
       "large": "https://images.pokemontcg.io/sv2/202_hires.png"
     },
-    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head."
+    "flavorText": "The combination of Crocalor's fire energy and overflowing vitality has caused an egg-shaped fireball to appear on the Pokémon's head.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-203",
@@ -11342,7 +12205,10 @@
       "small": "https://images.pokemontcg.io/sv2/203.png",
       "large": "https://images.pokemontcg.io/sv2/203_hires.png"
     },
-    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet."
+    "flavorText": "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-204",
@@ -11393,7 +12259,10 @@
       "small": "https://images.pokemontcg.io/sv2/204.png",
       "large": "https://images.pokemontcg.io/sv2/204_hires.png"
     },
-    "flavorText": "The fur on its body naturally repels water. It can stay dry even when it plays in the water."
+    "flavorText": "The fur on its body naturally repels water. It can stay dry even when it plays in the water.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-205",
@@ -11454,7 +12323,10 @@
       "small": "https://images.pokemontcg.io/sv2/205.png",
       "large": "https://images.pokemontcg.io/sv2/205_hires.png"
     },
-    "flavorText": "On hot days, these Pokémon press their ice cube heads together and pass the time cooling each other down."
+    "flavorText": "On hot days, these Pokémon press their ice cube heads together and pass the time cooling each other down.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-206",
@@ -11505,7 +12377,10 @@
       "small": "https://images.pokemontcg.io/sv2/206.png",
       "large": "https://images.pokemontcg.io/sv2/206_hires.png"
     },
-    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime."
+    "flavorText": "This Pokémon migrated to Paldea from distant lands long ago. The gel secreted by its feathers repels water and grime.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-207",
@@ -11566,7 +12441,10 @@
       "small": "https://images.pokemontcg.io/sv2/207.png",
       "large": "https://images.pokemontcg.io/sv2/207_hires.png"
     },
-    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully."
+    "flavorText": "These Pokémon constantly run through shallow waters to train their legs, then compete with each other to see which of them kicks most gracefully.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-208",
@@ -11617,7 +12495,10 @@
       "small": "https://images.pokemontcg.io/sv2/208.png",
       "large": "https://images.pokemontcg.io/sv2/208_hires.png"
     },
-    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores."
+    "flavorText": "Frigibax absorbs heat through its dorsal fin and converts the heat into ice energy. The higher the temperature, the more energy Frigibax stores.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-209",
@@ -11681,7 +12562,10 @@
       "small": "https://images.pokemontcg.io/sv2/209.png",
       "large": "https://images.pokemontcg.io/sv2/209_hires.png"
     },
-    "flavorText": "Arctibax freezes the air around it, protecting its face with an ice mask and turning its dorsal fin into a blade of ice."
+    "flavorText": "Arctibax freezes the air around it, protecting its face with an ice mask and turning its dorsal fin into a blade of ice.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-210",
@@ -11742,7 +12626,10 @@
       "small": "https://images.pokemontcg.io/sv2/210.png",
       "large": "https://images.pokemontcg.io/sv2/210_hires.png"
     },
-    "flavorText": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava."
+    "flavorText": "This Pokémon blasts cryogenic air out from its mouth. This air can instantly freeze even liquid-hot lava.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-211",
@@ -11804,7 +12691,10 @@
       "small": "https://images.pokemontcg.io/sv2/211.png",
       "large": "https://images.pokemontcg.io/sv2/211_hires.png"
     },
-    "flavorText": "Its tail discharges electricity into the ground, protecting it from getting shocked."
+    "flavorText": "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-212",
@@ -11869,7 +12759,10 @@
       "small": "https://images.pokemontcg.io/sv2/212.png",
       "large": "https://images.pokemontcg.io/sv2/212_hires.png"
     },
-    "flavorText": "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power."
+    "flavorText": "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-213",
@@ -11936,7 +12829,10 @@
       "small": "https://images.pokemontcg.io/sv2/213.png",
       "large": "https://images.pokemontcg.io/sv2/213_hires.png"
     },
-    "flavorText": "This Pokémon will hypnotize children to put them to sleep before carrying them away. Be wary of nights when the starlight is bright."
+    "flavorText": "This Pokémon will hypnotize children to put them to sleep before carrying them away. Be wary of nights when the starlight is bright.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-214",
@@ -12006,7 +12902,10 @@
       "small": "https://images.pokemontcg.io/sv2/214.png",
       "large": "https://images.pokemontcg.io/sv2/214_hires.png"
     },
-    "flavorText": "If it loses its shovel, it will stick something else— like a branch—in its head to make do until it finds another shovel."
+    "flavorText": "If it loses its shovel, it will stick something else— like a branch—in its head to make do until it finds another shovel.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-215",
@@ -12073,7 +12972,10 @@
       "small": "https://images.pokemontcg.io/sv2/215.png",
       "large": "https://images.pokemontcg.io/sv2/215_hires.png"
     },
-    "flavorText": "The body that supports the ball barely moves. Therefore, it is thought that the true body of this Pokémon is actually inside the ball."
+    "flavorText": "The body that supports the ball barely moves. Therefore, it is thought that the true body of this Pokémon is actually inside the ball.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-216",
@@ -12134,7 +13036,10 @@
       "small": "https://images.pokemontcg.io/sv2/216.png",
       "large": "https://images.pokemontcg.io/sv2/216_hires.png"
     },
-    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal."
+    "flavorText": "It swings its handmade hammer around to protect itself, but the hammer is often stolen by Pokémon that eat metal.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-217",
@@ -12198,7 +13103,10 @@
       "small": "https://images.pokemontcg.io/sv2/217.png",
       "large": "https://images.pokemontcg.io/sv2/217_hires.png"
     },
-    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer."
+    "flavorText": "This Pokémon will attack groups of Pawniard and Bisharp, gathering metal from them in order to create a large and sturdy hammer.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-218",
@@ -12261,7 +13169,10 @@
       "small": "https://images.pokemontcg.io/sv2/218.png",
       "large": "https://images.pokemontcg.io/sv2/218_hires.png"
     },
-    "flavorText": "This kind of Tauros, known as the Combat Breed, is distinguished by its thick, powerful muscles and its fierce disposition."
+    "flavorText": "This kind of Tauros, known as the Combat Breed, is distinguished by its thick, powerful muscles and its fierce disposition.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-219",
@@ -12322,7 +13233,10 @@
       "small": "https://images.pokemontcg.io/sv2/219.png",
       "large": "https://images.pokemontcg.io/sv2/219_hires.png"
     },
-    "flavorText": "Although it always pretends to be a tree, its composition appears more similar to rock than to vegetation."
+    "flavorText": "Although it always pretends to be a tree, its composition appears more similar to rock than to vegetation.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-220",
@@ -12384,7 +13298,10 @@
       "small": "https://images.pokemontcg.io/sv2/220.png",
       "large": "https://images.pokemontcg.io/sv2/220_hires.png"
     },
-    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt."
+    "flavorText": "It was born in a layer of rock salt deep under the earth. This species was particularly treasured in the old days, as they would share precious salt.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-221",
@@ -12444,7 +13361,10 @@
       "small": "https://images.pokemontcg.io/sv2/221.png",
       "large": "https://images.pokemontcg.io/sv2/221_hires.png"
     },
-    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body."
+    "flavorText": "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-222",
@@ -12507,7 +13427,10 @@
       "small": "https://images.pokemontcg.io/sv2/222.png",
       "large": "https://images.pokemontcg.io/sv2/222_hires.png"
     },
-    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others."
+    "flavorText": "Extremely strong, it can change the landscape. It is so insolent that it doesn't care about others.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-223",
@@ -12567,7 +13490,10 @@
       "small": "https://images.pokemontcg.io/sv2/223.png",
       "large": "https://images.pokemontcg.io/sv2/223_hires.png"
     },
-    "flavorText": "The color of the poisonous saliva depends on what the Pokémon eats. Grafaiai covers its fingers in its saliva and draws patterns on trees in forests."
+    "flavorText": "The color of the poisonous saliva depends on what the Pokémon eats. Grafaiai covers its fingers in its saliva and draws patterns on trees in forests.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-224",
@@ -12634,7 +13560,10 @@
       "small": "https://images.pokemontcg.io/sv2/224.png",
       "large": "https://images.pokemontcg.io/sv2/224_hires.png"
     },
-    "flavorText": "When attacked, this Pokémon will wield the tendrils on its body like fists and pelt the opponent with a storm of punches."
+    "flavorText": "When attacked, this Pokémon will wield the tendrils on its body like fists and pelt the opponent with a storm of punches.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-225",
@@ -12690,7 +13619,10 @@
       "small": "https://images.pokemontcg.io/sv2/225.png",
       "large": "https://images.pokemontcg.io/sv2/225_hires.png"
     },
-    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon."
+    "flavorText": "This Pokémon is brave and reckless. The white markings around a Rookidee's eyes intimidate fainthearted Pokémon.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-226",
@@ -12753,7 +13685,10 @@
       "small": "https://images.pokemontcg.io/sv2/226.png",
       "large": "https://images.pokemontcg.io/sv2/226_hires.png"
     },
-    "flavorText": "They build huge nests with many rooms that are used for different purposes, such as eating and sleeping."
+    "flavorText": "They build huge nests with many rooms that are used for different purposes, such as eating and sleeping.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-227",
@@ -12817,7 +13752,10 @@
       "small": "https://images.pokemontcg.io/sv2/227.png",
       "large": "https://images.pokemontcg.io/sv2/227_hires.png"
     },
-    "flavorText": "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak."
+    "flavorText": "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-228",
@@ -12880,7 +13818,10 @@
       "small": "https://images.pokemontcg.io/sv2/228.png",
       "large": "https://images.pokemontcg.io/sv2/228_hires.png"
     },
-    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's."
+    "flavorText": "Now that the brain waves from the head and tail are synced up, the psychic power of this Pokémon is 10 times stronger than Girafarig's.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-229",
@@ -12945,7 +13886,10 @@
       "small": "https://images.pokemontcg.io/sv2/229.png",
       "large": "https://images.pokemontcg.io/sv2/229_hires.png"
     },
-    "flavorText": "This Pokémon uses its hard tail to make its nest by boring holes into bedrock deep underground. The nest can reach lengths of over six miles."
+    "flavorText": "This Pokémon uses its hard tail to make its nest by boring holes into bedrock deep underground. The nest can reach lengths of over six miles.",
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-230",
@@ -13011,7 +13955,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/230.png",
       "large": "https://images.pokemontcg.io/sv2/230_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-231",
@@ -13074,7 +14021,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/231.png",
       "large": "https://images.pokemontcg.io/sv2/231_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-232",
@@ -13144,7 +14094,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/232.png",
       "large": "https://images.pokemontcg.io/sv2/232_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-233",
@@ -13210,7 +14163,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/233.png",
       "large": "https://images.pokemontcg.io/sv2/233_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-234",
@@ -13273,7 +14229,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/234.png",
       "large": "https://images.pokemontcg.io/sv2/234_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-235",
@@ -13338,7 +14297,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/235.png",
       "large": "https://images.pokemontcg.io/sv2/235_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-236",
@@ -13400,7 +14362,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/236.png",
       "large": "https://images.pokemontcg.io/sv2/236_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-237",
@@ -13468,7 +14433,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/237.png",
       "large": "https://images.pokemontcg.io/sv2/237_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-238",
@@ -13542,7 +14510,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/238.png",
       "large": "https://images.pokemontcg.io/sv2/238_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-239",
@@ -13609,7 +14580,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/239.png",
       "large": "https://images.pokemontcg.io/sv2/239_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-240",
@@ -13676,7 +14650,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/240.png",
       "large": "https://images.pokemontcg.io/sv2/240_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-241",
@@ -13742,7 +14719,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/241.png",
       "large": "https://images.pokemontcg.io/sv2/241_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-242",
@@ -13807,7 +14787,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/242.png",
       "large": "https://images.pokemontcg.io/sv2/242_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-243",
@@ -13872,7 +14855,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/243.png",
       "large": "https://images.pokemontcg.io/sv2/243_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-244",
@@ -13937,7 +14923,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/244.png",
       "large": "https://images.pokemontcg.io/sv2/244_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-245",
@@ -14009,7 +14998,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/245.png",
       "large": "https://images.pokemontcg.io/sv2/245_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-246",
@@ -14064,7 +15056,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/246.png",
       "large": "https://images.pokemontcg.io/sv2/246_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-247",
@@ -14130,7 +15125,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/247.png",
       "large": "https://images.pokemontcg.io/sv2/247_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-248",
@@ -14155,7 +15153,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/248.png",
       "large": "https://images.pokemontcg.io/sv2/248_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-249",
@@ -14180,7 +15181,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/249.png",
       "large": "https://images.pokemontcg.io/sv2/249_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-250",
@@ -14205,7 +15209,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/250.png",
       "large": "https://images.pokemontcg.io/sv2/250_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-251",
@@ -14230,7 +15237,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/251.png",
       "large": "https://images.pokemontcg.io/sv2/251_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-252",
@@ -14255,7 +15265,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/252.png",
       "large": "https://images.pokemontcg.io/sv2/252_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-253",
@@ -14280,7 +15293,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/253.png",
       "large": "https://images.pokemontcg.io/sv2/253_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-254",
@@ -14305,7 +15321,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/254.png",
       "large": "https://images.pokemontcg.io/sv2/254_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-255",
@@ -14330,7 +15349,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/255.png",
       "large": "https://images.pokemontcg.io/sv2/255_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-256",
@@ -14393,7 +15415,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/256.png",
       "large": "https://images.pokemontcg.io/sv2/256_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-257",
@@ -14463,7 +15488,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/257.png",
       "large": "https://images.pokemontcg.io/sv2/257_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-258",
@@ -14529,7 +15557,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/258.png",
       "large": "https://images.pokemontcg.io/sv2/258_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-259",
@@ -14592,7 +15623,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/259.png",
       "large": "https://images.pokemontcg.io/sv2/259_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-260",
@@ -14657,7 +15691,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/260.png",
       "large": "https://images.pokemontcg.io/sv2/260_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-261",
@@ -14719,7 +15756,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/261.png",
       "large": "https://images.pokemontcg.io/sv2/261_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-262",
@@ -14786,7 +15826,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/262.png",
       "large": "https://images.pokemontcg.io/sv2/262_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-263",
@@ -14851,7 +15894,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/263.png",
       "large": "https://images.pokemontcg.io/sv2/263_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-264",
@@ -14917,7 +15963,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/264.png",
       "large": "https://images.pokemontcg.io/sv2/264_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-265",
@@ -14942,7 +15991,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/265.png",
       "large": "https://images.pokemontcg.io/sv2/265_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-266",
@@ -14967,7 +16019,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/266.png",
       "large": "https://images.pokemontcg.io/sv2/266_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-267",
@@ -14992,7 +16047,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/267.png",
       "large": "https://images.pokemontcg.io/sv2/267_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-268",
@@ -15017,7 +16075,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/268.png",
       "large": "https://images.pokemontcg.io/sv2/268_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-269",
@@ -15042,7 +16103,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/269.png",
       "large": "https://images.pokemontcg.io/sv2/269_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-270",
@@ -15067,7 +16131,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/270.png",
       "large": "https://images.pokemontcg.io/sv2/270_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-271",
@@ -15130,7 +16197,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/271.png",
       "large": "https://images.pokemontcg.io/sv2/271_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-272",
@@ -15196,7 +16266,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/272.png",
       "large": "https://images.pokemontcg.io/sv2/272_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-273",
@@ -15261,7 +16334,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/273.png",
       "large": "https://images.pokemontcg.io/sv2/273_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-274",
@@ -15323,7 +16399,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/274.png",
       "large": "https://images.pokemontcg.io/sv2/274_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-275",
@@ -15388,7 +16467,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/275.png",
       "large": "https://images.pokemontcg.io/sv2/275_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-276",
@@ -15413,7 +16495,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/276.png",
       "large": "https://images.pokemontcg.io/sv2/276_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-277",
@@ -15438,7 +16523,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/277.png",
       "large": "https://images.pokemontcg.io/sv2/277_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-278",
@@ -15457,7 +16545,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/278.png",
       "large": "https://images.pokemontcg.io/sv2/278_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv2-279",
@@ -15476,6 +16567,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv2/279.png",
       "large": "https://images.pokemontcg.io/sv2/279_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv3.json
+++ b/cards/en/sv3.json
@@ -59,7 +59,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/1.png",
       "large": "https://images.pokemontcg.io/sv3/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-2",
@@ -124,7 +128,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/2.png",
       "large": "https://images.pokemontcg.io/sv3/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-3",
@@ -184,7 +192,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/3.png",
       "large": "https://images.pokemontcg.io/sv3/3_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-4",
@@ -248,7 +260,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/4.png",
       "large": "https://images.pokemontcg.io/sv3/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-5",
@@ -308,7 +324,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/5.png",
       "large": "https://images.pokemontcg.io/sv3/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-6",
@@ -361,7 +381,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/6.png",
       "large": "https://images.pokemontcg.io/sv3/6_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-7",
@@ -422,7 +446,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/7.png",
       "large": "https://images.pokemontcg.io/sv3/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-8",
@@ -485,7 +513,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/8.png",
       "large": "https://images.pokemontcg.io/sv3/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-9",
@@ -548,7 +580,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/9.png",
       "large": "https://images.pokemontcg.io/sv3/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-10",
@@ -601,7 +637,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/10.png",
       "large": "https://images.pokemontcg.io/sv3/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-11",
@@ -655,7 +695,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/11.png",
       "large": "https://images.pokemontcg.io/sv3/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-12",
@@ -717,7 +761,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/12.png",
       "large": "https://images.pokemontcg.io/sv3/12_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-13",
@@ -770,7 +818,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/13.png",
       "large": "https://images.pokemontcg.io/sv3/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-14",
@@ -825,7 +877,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/14.png",
       "large": "https://images.pokemontcg.io/sv3/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-15",
@@ -888,7 +944,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/15.png",
       "large": "https://images.pokemontcg.io/sv3/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-16",
@@ -951,7 +1010,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/16.png",
       "large": "https://images.pokemontcg.io/sv3/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-17",
@@ -1015,7 +1078,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/17.png",
       "large": "https://images.pokemontcg.io/sv3/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-18",
@@ -1077,7 +1144,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/18.png",
       "large": "https://images.pokemontcg.io/sv3/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-19",
@@ -1130,7 +1201,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/19.png",
       "large": "https://images.pokemontcg.io/sv3/19_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-20",
@@ -1184,7 +1259,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/20.png",
       "large": "https://images.pokemontcg.io/sv3/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-21",
@@ -1245,7 +1324,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/21.png",
       "large": "https://images.pokemontcg.io/sv3/21_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-22",
@@ -1308,7 +1391,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/22.png",
       "large": "https://images.pokemontcg.io/sv3/22_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-23",
@@ -1361,7 +1448,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/23.png",
       "large": "https://images.pokemontcg.io/sv3/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-24",
@@ -1417,7 +1508,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/24.png",
       "large": "https://images.pokemontcg.io/sv3/24_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-25",
@@ -1478,7 +1573,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/25.png",
       "large": "https://images.pokemontcg.io/sv3/25_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-26",
@@ -1531,7 +1631,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/26.png",
       "large": "https://images.pokemontcg.io/sv3/26_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv3-27",
@@ -1587,7 +1692,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/27.png",
       "large": "https://images.pokemontcg.io/sv3/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Holo"
+    ]
   },
   {
     "id": "sv3-28",
@@ -1650,7 +1760,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/28.png",
       "large": "https://images.pokemontcg.io/sv3/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-29",
@@ -1711,7 +1825,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/29.png",
       "large": "https://images.pokemontcg.io/sv3/29_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-30",
@@ -1771,7 +1889,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/30.png",
       "large": "https://images.pokemontcg.io/sv3/30_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-31",
@@ -1827,7 +1949,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/31.png",
       "large": "https://images.pokemontcg.io/sv3/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-32",
@@ -1892,7 +2018,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/32.png",
       "large": "https://images.pokemontcg.io/sv3/32_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-33",
@@ -1956,7 +2086,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/33.png",
       "large": "https://images.pokemontcg.io/sv3/33_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-34",
@@ -2022,7 +2155,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/34.png",
       "large": "https://images.pokemontcg.io/sv3/34_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-35",
@@ -2089,7 +2226,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/35.png",
       "large": "https://images.pokemontcg.io/sv3/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-36",
@@ -2142,7 +2283,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/36.png",
       "large": "https://images.pokemontcg.io/sv3/36_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-37",
@@ -2206,7 +2351,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/37.png",
       "large": "https://images.pokemontcg.io/sv3/37_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-38",
@@ -2269,7 +2418,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/38.png",
       "large": "https://images.pokemontcg.io/sv3/38_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-39",
@@ -2320,7 +2473,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/39.png",
       "large": "https://images.pokemontcg.io/sv3/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-40",
@@ -2384,7 +2541,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/40.png",
       "large": "https://images.pokemontcg.io/sv3/40_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-41",
@@ -2447,7 +2608,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/41.png",
       "large": "https://images.pokemontcg.io/sv3/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-42",
@@ -2505,7 +2670,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/42.png",
       "large": "https://images.pokemontcg.io/sv3/42_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-43",
@@ -2569,7 +2737,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/43.png",
       "large": "https://images.pokemontcg.io/sv3/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-44",
@@ -2628,7 +2800,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/44.png",
       "large": "https://images.pokemontcg.io/sv3/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-45",
@@ -2690,7 +2866,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/45.png",
       "large": "https://images.pokemontcg.io/sv3/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-46",
@@ -2743,7 +2923,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/46.png",
       "large": "https://images.pokemontcg.io/sv3/46_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-47",
@@ -2804,7 +2988,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/47.png",
       "large": "https://images.pokemontcg.io/sv3/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-48",
@@ -2857,7 +3045,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/48.png",
       "large": "https://images.pokemontcg.io/sv3/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-49",
@@ -2918,7 +3110,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/49.png",
       "large": "https://images.pokemontcg.io/sv3/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-50",
@@ -2971,7 +3167,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/50.png",
       "large": "https://images.pokemontcg.io/sv3/50_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-51",
@@ -3027,7 +3227,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/51.png",
       "large": "https://images.pokemontcg.io/sv3/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-52",
@@ -3088,7 +3292,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/52.png",
       "large": "https://images.pokemontcg.io/sv3/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-53",
@@ -3152,7 +3360,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/53.png",
       "large": "https://images.pokemontcg.io/sv3/53_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-54",
@@ -3216,7 +3428,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/54.png",
       "large": "https://images.pokemontcg.io/sv3/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-55",
@@ -3266,7 +3482,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/55.png",
       "large": "https://images.pokemontcg.io/sv3/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-56",
@@ -3319,7 +3539,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/56.png",
       "large": "https://images.pokemontcg.io/sv3/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-57",
@@ -3374,7 +3599,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/57.png",
       "large": "https://images.pokemontcg.io/sv3/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-58",
@@ -3427,7 +3657,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/58.png",
       "large": "https://images.pokemontcg.io/sv3/58_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-59",
@@ -3478,7 +3712,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/59.png",
       "large": "https://images.pokemontcg.io/sv3/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-60",
@@ -3541,7 +3779,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/60.png",
       "large": "https://images.pokemontcg.io/sv3/60_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-61",
@@ -3596,7 +3838,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/61.png",
       "large": "https://images.pokemontcg.io/sv3/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-62",
@@ -3658,7 +3904,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/62.png",
       "large": "https://images.pokemontcg.io/sv3/62_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv3-63",
@@ -3721,7 +3973,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/63.png",
       "large": "https://images.pokemontcg.io/sv3/63_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-64",
@@ -3787,7 +4043,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/64.png",
       "large": "https://images.pokemontcg.io/sv3/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-65",
@@ -3850,7 +4110,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/65.png",
       "large": "https://images.pokemontcg.io/sv3/65_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-66",
@@ -3919,7 +4183,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/66.png",
       "large": "https://images.pokemontcg.io/sv3/66_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-67",
@@ -3982,7 +4250,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/67.png",
       "large": "https://images.pokemontcg.io/sv3/67_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-68",
@@ -4048,7 +4320,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/68.png",
       "large": "https://images.pokemontcg.io/sv3/68_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-69",
@@ -4112,7 +4388,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/69.png",
       "large": "https://images.pokemontcg.io/sv3/69_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-70",
@@ -4171,7 +4451,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/70.png",
       "large": "https://images.pokemontcg.io/sv3/70_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-71",
@@ -4224,7 +4508,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/71.png",
       "large": "https://images.pokemontcg.io/sv3/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-72",
@@ -4286,7 +4574,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/72.png",
       "large": "https://images.pokemontcg.io/sv3/72_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv3-73",
@@ -4346,7 +4639,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/73.png",
       "large": "https://images.pokemontcg.io/sv3/73_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-74",
@@ -4410,7 +4706,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/74.png",
       "large": "https://images.pokemontcg.io/sv3/74_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-75",
@@ -4464,7 +4764,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/75.png",
       "large": "https://images.pokemontcg.io/sv3/75_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-76",
@@ -4519,7 +4823,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/76.png",
       "large": "https://images.pokemontcg.io/sv3/76_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-77",
@@ -4572,7 +4880,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/77.png",
       "large": "https://images.pokemontcg.io/sv3/77_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-78",
@@ -4634,7 +4946,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/78.png",
       "large": "https://images.pokemontcg.io/sv3/78_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-79",
@@ -4694,7 +5010,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/79.png",
       "large": "https://images.pokemontcg.io/sv3/79_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-80",
@@ -4741,7 +5060,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/80.png",
       "large": "https://images.pokemontcg.io/sv3/80_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-81",
@@ -4795,7 +5118,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/81.png",
       "large": "https://images.pokemontcg.io/sv3/81_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-82",
@@ -4859,7 +5186,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/82.png",
       "large": "https://images.pokemontcg.io/sv3/82_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-83",
@@ -4922,7 +5252,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/83.png",
       "large": "https://images.pokemontcg.io/sv3/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-84",
@@ -4986,7 +5320,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/84.png",
       "large": "https://images.pokemontcg.io/sv3/84_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-85",
@@ -5041,7 +5379,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/85.png",
       "large": "https://images.pokemontcg.io/sv3/85_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv3-86",
@@ -5108,7 +5452,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/86.png",
       "large": "https://images.pokemontcg.io/sv3/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv3-87",
@@ -5172,7 +5521,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/87.png",
       "large": "https://images.pokemontcg.io/sv3/87_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-88",
@@ -5236,7 +5589,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/88.png",
       "large": "https://images.pokemontcg.io/sv3/88_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-89",
@@ -5287,7 +5644,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/89.png",
       "large": "https://images.pokemontcg.io/sv3/89_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-90",
@@ -5356,7 +5717,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/90.png",
       "large": "https://images.pokemontcg.io/sv3/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-91",
@@ -5424,7 +5789,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/91.png",
       "large": "https://images.pokemontcg.io/sv3/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-92",
@@ -5489,7 +5858,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/92.png",
       "large": "https://images.pokemontcg.io/sv3/92_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-93",
@@ -5555,7 +5929,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/93.png",
       "large": "https://images.pokemontcg.io/sv3/93_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-94",
@@ -5615,7 +5993,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/94.png",
       "large": "https://images.pokemontcg.io/sv3/94_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-95",
@@ -5682,7 +6064,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/95.png",
       "large": "https://images.pokemontcg.io/sv3/95_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-96",
@@ -5756,7 +6143,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/96.png",
       "large": "https://images.pokemontcg.io/sv3/96_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-97",
@@ -5815,7 +6205,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/97.png",
       "large": "https://images.pokemontcg.io/sv3/97_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-98",
@@ -5882,7 +6276,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/98.png",
       "large": "https://images.pokemontcg.io/sv3/98_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-99",
@@ -5952,7 +6350,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/99.png",
       "large": "https://images.pokemontcg.io/sv3/99_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-100",
@@ -6015,7 +6417,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/100.png",
       "large": "https://images.pokemontcg.io/sv3/100_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-101",
@@ -6086,7 +6492,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/101.png",
       "large": "https://images.pokemontcg.io/sv3/101_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-102",
@@ -6159,7 +6569,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/102.png",
       "large": "https://images.pokemontcg.io/sv3/102_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-103",
@@ -6212,7 +6625,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/103.png",
       "large": "https://images.pokemontcg.io/sv3/103_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-104",
@@ -6263,7 +6680,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/104.png",
       "large": "https://images.pokemontcg.io/sv3/104_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-105",
@@ -6326,7 +6747,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/105.png",
       "large": "https://images.pokemontcg.io/sv3/105_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-106",
@@ -6390,7 +6815,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/106.png",
       "large": "https://images.pokemontcg.io/sv3/106_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-107",
@@ -6455,7 +6884,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/107.png",
       "large": "https://images.pokemontcg.io/sv3/107_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-108",
@@ -6519,7 +6952,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/108.png",
       "large": "https://images.pokemontcg.io/sv3/108_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-109",
@@ -6584,7 +7021,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/109.png",
       "large": "https://images.pokemontcg.io/sv3/109_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-110",
@@ -6631,7 +7072,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/110.png",
       "large": "https://images.pokemontcg.io/sv3/110_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-111",
@@ -6685,7 +7130,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/111.png",
       "large": "https://images.pokemontcg.io/sv3/111_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-112",
@@ -6744,7 +7193,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/112.png",
       "large": "https://images.pokemontcg.io/sv3/112_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-113",
@@ -6810,7 +7263,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/113.png",
       "large": "https://images.pokemontcg.io/sv3/113_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-114",
@@ -6877,7 +7334,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/114.png",
       "large": "https://images.pokemontcg.io/sv3/114_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-115",
@@ -6943,7 +7404,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/115.png",
       "large": "https://images.pokemontcg.io/sv3/115_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-116",
@@ -6996,7 +7461,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/116.png",
       "large": "https://images.pokemontcg.io/sv3/116_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-117",
@@ -7059,7 +7528,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/117.png",
       "large": "https://images.pokemontcg.io/sv3/117_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-118",
@@ -7122,7 +7595,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/118.png",
       "large": "https://images.pokemontcg.io/sv3/118_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-119",
@@ -7186,7 +7663,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/119.png",
       "large": "https://images.pokemontcg.io/sv3/119_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-120",
@@ -7250,7 +7731,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/120.png",
       "large": "https://images.pokemontcg.io/sv3/120_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-121",
@@ -7312,7 +7796,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/121.png",
       "large": "https://images.pokemontcg.io/sv3/121_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-122",
@@ -7367,7 +7855,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/122.png",
       "large": "https://images.pokemontcg.io/sv3/122_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-123",
@@ -7431,7 +7923,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/123.png",
       "large": "https://images.pokemontcg.io/sv3/123_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-124",
@@ -7496,7 +7991,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/124.png",
       "large": "https://images.pokemontcg.io/sv3/124_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-125",
@@ -7561,7 +8059,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/125.png",
       "large": "https://images.pokemontcg.io/sv3/125_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-126",
@@ -7615,7 +8118,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/126.png",
       "large": "https://images.pokemontcg.io/sv3/126_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-127",
@@ -7671,7 +8178,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/127.png",
       "large": "https://images.pokemontcg.io/sv3/127_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-128",
@@ -7735,7 +8246,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/128.png",
       "large": "https://images.pokemontcg.io/sv3/128_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-129",
@@ -7799,7 +8314,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/129.png",
       "large": "https://images.pokemontcg.io/sv3/129_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-130",
@@ -7861,7 +8380,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/130.png",
       "large": "https://images.pokemontcg.io/sv3/130_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "EB Games",
+      "GameStop",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv3-131",
@@ -7924,7 +8450,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/131.png",
       "large": "https://images.pokemontcg.io/sv3/131_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-132",
@@ -7988,7 +8518,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/132.png",
       "large": "https://images.pokemontcg.io/sv3/132_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-133",
@@ -8052,7 +8586,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/133.png",
       "large": "https://images.pokemontcg.io/sv3/133_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-134",
@@ -8119,7 +8657,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/134.png",
       "large": "https://images.pokemontcg.io/sv3/134_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-135",
@@ -8183,7 +8724,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/135.png",
       "large": "https://images.pokemontcg.io/sv3/135_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-136",
@@ -8245,7 +8789,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/136.png",
       "large": "https://images.pokemontcg.io/sv3/136_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-137",
@@ -8299,7 +8848,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/137.png",
       "large": "https://images.pokemontcg.io/sv3/137_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-138",
@@ -8360,7 +8913,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/138.png",
       "large": "https://images.pokemontcg.io/sv3/138_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-139",
@@ -8423,7 +8980,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/139.png",
       "large": "https://images.pokemontcg.io/sv3/139_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-140",
@@ -8484,7 +9045,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/140.png",
       "large": "https://images.pokemontcg.io/sv3/140_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-141",
@@ -8552,7 +9117,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/141.png",
       "large": "https://images.pokemontcg.io/sv3/141_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-142",
@@ -8619,7 +9188,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/142.png",
       "large": "https://images.pokemontcg.io/sv3/142_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-143",
@@ -8684,7 +9257,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/143.png",
       "large": "https://images.pokemontcg.io/sv3/143_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-144",
@@ -8754,7 +9331,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/144.png",
       "large": "https://images.pokemontcg.io/sv3/144_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-145",
@@ -8823,7 +9404,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/145.png",
       "large": "https://images.pokemontcg.io/sv3/145_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-146",
@@ -8895,7 +9480,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/146.png",
       "large": "https://images.pokemontcg.io/sv3/146_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-147",
@@ -8953,7 +9542,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/147.png",
       "large": "https://images.pokemontcg.io/sv3/147_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-148",
@@ -9012,7 +9605,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/148.png",
       "large": "https://images.pokemontcg.io/sv3/148_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-149",
@@ -9083,7 +9681,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/149.png",
       "large": "https://images.pokemontcg.io/sv3/149_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3-150",
@@ -9154,7 +9757,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/150.png",
       "large": "https://images.pokemontcg.io/sv3/150_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-151",
@@ -9220,7 +9827,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/151.png",
       "large": "https://images.pokemontcg.io/sv3/151_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-152",
@@ -9279,7 +9890,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/152.png",
       "large": "https://images.pokemontcg.io/sv3/152_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-153",
@@ -9354,7 +9969,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/153.png",
       "large": "https://images.pokemontcg.io/sv3/153_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-154",
@@ -9413,7 +10031,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/154.png",
       "large": "https://images.pokemontcg.io/sv3/154_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-155",
@@ -9474,7 +10096,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/155.png",
       "large": "https://images.pokemontcg.io/sv3/155_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-156",
@@ -9543,7 +10169,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/156.png",
       "large": "https://images.pokemontcg.io/sv3/156_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-157",
@@ -9590,7 +10219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/157.png",
       "large": "https://images.pokemontcg.io/sv3/157_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-158",
@@ -9649,7 +10282,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/158.png",
       "large": "https://images.pokemontcg.io/sv3/158_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-159",
@@ -9710,7 +10347,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/159.png",
       "large": "https://images.pokemontcg.io/sv3/159_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-160",
@@ -9765,7 +10405,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/160.png",
       "large": "https://images.pokemontcg.io/sv3/160_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-161",
@@ -9811,7 +10455,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/161.png",
       "large": "https://images.pokemontcg.io/sv3/161_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-162",
@@ -9870,7 +10518,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/162.png",
       "large": "https://images.pokemontcg.io/sv3/162_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-163",
@@ -9931,7 +10583,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/163.png",
       "large": "https://images.pokemontcg.io/sv3/163_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-164",
@@ -9995,7 +10651,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/164.png",
       "large": "https://images.pokemontcg.io/sv3/164_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-165",
@@ -10056,7 +10716,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/165.png",
       "large": "https://images.pokemontcg.io/sv3/165_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-166",
@@ -10126,7 +10790,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/166.png",
       "large": "https://images.pokemontcg.io/sv3/166_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-167",
@@ -10189,7 +10857,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/167.png",
       "large": "https://images.pokemontcg.io/sv3/167_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-168",
@@ -10250,7 +10922,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/168.png",
       "large": "https://images.pokemontcg.io/sv3/168_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-169",
@@ -10319,7 +10995,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/169.png",
       "large": "https://images.pokemontcg.io/sv3/169_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-170",
@@ -10372,7 +11052,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/170.png",
       "large": "https://images.pokemontcg.io/sv3/170_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-171",
@@ -10437,7 +11121,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/171.png",
       "large": "https://images.pokemontcg.io/sv3/171_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-172",
@@ -10501,7 +11189,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/172.png",
       "large": "https://images.pokemontcg.io/sv3/172_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-173",
@@ -10562,7 +11254,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/173.png",
       "large": "https://images.pokemontcg.io/sv3/173_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-174",
@@ -10621,7 +11317,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/174.png",
       "large": "https://images.pokemontcg.io/sv3/174_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-175",
@@ -10674,7 +11374,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/175.png",
       "large": "https://images.pokemontcg.io/sv3/175_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-176",
@@ -10727,7 +11431,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/176.png",
       "large": "https://images.pokemontcg.io/sv3/176_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-177",
@@ -10789,7 +11497,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/177.png",
       "large": "https://images.pokemontcg.io/sv3/177_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-178",
@@ -10851,7 +11563,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/178.png",
       "large": "https://images.pokemontcg.io/sv3/178_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-179",
@@ -10919,7 +11635,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/179.png",
       "large": "https://images.pokemontcg.io/sv3/179_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-180",
@@ -10972,7 +11691,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/180.png",
       "large": "https://images.pokemontcg.io/sv3/180_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-181",
@@ -11027,7 +11750,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/181.png",
       "large": "https://images.pokemontcg.io/sv3/181_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-182",
@@ -11091,7 +11818,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/182.png",
       "large": "https://images.pokemontcg.io/sv3/182_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-183",
@@ -11155,7 +11886,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/183.png",
       "large": "https://images.pokemontcg.io/sv3/183_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-184",
@@ -11219,7 +11954,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/184.png",
       "large": "https://images.pokemontcg.io/sv3/184_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-185",
@@ -11286,7 +12025,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/185.png",
       "large": "https://images.pokemontcg.io/sv3/185_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-186",
@@ -11311,7 +12054,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/186.png",
       "large": "https://images.pokemontcg.io/sv3/186_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-187",
@@ -11336,7 +12083,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/187.png",
       "large": "https://images.pokemontcg.io/sv3/187_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-188",
@@ -11361,7 +12112,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/188.png",
       "large": "https://images.pokemontcg.io/sv3/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Regional Championship",
+      "Regional Championship (Staff)"
+    ]
   },
   {
     "id": "sv3-189",
@@ -11387,7 +12144,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/189.png",
       "large": "https://images.pokemontcg.io/sv3/189_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv3-190",
@@ -11412,7 +12174,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/190.png",
       "large": "https://images.pokemontcg.io/sv3/190_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-191",
@@ -11437,7 +12203,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/191.png",
       "large": "https://images.pokemontcg.io/sv3/191_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-192",
@@ -11462,7 +12232,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/192.png",
       "large": "https://images.pokemontcg.io/sv3/192_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-193",
@@ -11487,7 +12261,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/193.png",
       "large": "https://images.pokemontcg.io/sv3/193_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-194",
@@ -11512,7 +12290,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/194.png",
       "large": "https://images.pokemontcg.io/sv3/194_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-195",
@@ -11537,7 +12319,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/195.png",
       "large": "https://images.pokemontcg.io/sv3/195_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-196",
@@ -11562,7 +12348,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/196.png",
       "large": "https://images.pokemontcg.io/sv3/196_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-197",
@@ -11587,7 +12377,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/197.png",
       "large": "https://images.pokemontcg.io/sv3/197_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3-198",
@@ -11652,7 +12446,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/198.png",
       "large": "https://images.pokemontcg.io/sv3/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-199",
@@ -11713,7 +12510,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/199.png",
       "large": "https://images.pokemontcg.io/sv3/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-200",
@@ -11775,7 +12575,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/200.png",
       "large": "https://images.pokemontcg.io/sv3/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-201",
@@ -11837,7 +12640,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/201.png",
       "large": "https://images.pokemontcg.io/sv3/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-202",
@@ -11884,7 +12690,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/202.png",
       "large": "https://images.pokemontcg.io/sv3/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-203",
@@ -11947,7 +12756,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/203.png",
       "large": "https://images.pokemontcg.io/sv3/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-204",
@@ -12010,7 +12822,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/204.png",
       "large": "https://images.pokemontcg.io/sv3/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-205",
@@ -12078,7 +12893,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/205.png",
       "large": "https://images.pokemontcg.io/sv3/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-206",
@@ -12137,7 +12955,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/206.png",
       "large": "https://images.pokemontcg.io/sv3/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-207",
@@ -12196,7 +13017,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/207.png",
       "large": "https://images.pokemontcg.io/sv3/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-208",
@@ -12257,7 +13081,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/208.png",
       "large": "https://images.pokemontcg.io/sv3/208_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-209",
@@ -12310,7 +13137,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/209.png",
       "large": "https://images.pokemontcg.io/sv3/209_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-210",
@@ -12368,7 +13198,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/210.png",
       "large": "https://images.pokemontcg.io/sv3/210_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-211",
@@ -12437,7 +13270,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/211.png",
       "large": "https://images.pokemontcg.io/sv3/211_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-212",
@@ -12511,7 +13347,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/212.png",
       "large": "https://images.pokemontcg.io/sv3/212_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-213",
@@ -12575,7 +13414,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/213.png",
       "large": "https://images.pokemontcg.io/sv3/213_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-214",
@@ -12639,7 +13481,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/214.png",
       "large": "https://images.pokemontcg.io/sv3/214_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-215",
@@ -12704,7 +13549,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/215.png",
       "large": "https://images.pokemontcg.io/sv3/215_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-216",
@@ -12773,7 +13621,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/216.png",
       "large": "https://images.pokemontcg.io/sv3/216_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-217",
@@ -12837,7 +13688,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/217.png",
       "large": "https://images.pokemontcg.io/sv3/217_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-218",
@@ -12862,7 +13716,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/218.png",
       "large": "https://images.pokemontcg.io/sv3/218_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-219",
@@ -12887,7 +13744,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/219.png",
       "large": "https://images.pokemontcg.io/sv3/219_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-220",
@@ -12912,7 +13772,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/220.png",
       "large": "https://images.pokemontcg.io/sv3/220_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-221",
@@ -12937,7 +13800,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/221.png",
       "large": "https://images.pokemontcg.io/sv3/221_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-222",
@@ -12995,7 +13861,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/222.png",
       "large": "https://images.pokemontcg.io/sv3/222_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-223",
@@ -13060,7 +13929,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/223.png",
       "large": "https://images.pokemontcg.io/sv3/223_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-224",
@@ -13129,7 +14001,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/224.png",
       "large": "https://images.pokemontcg.io/sv3/224_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-225",
@@ -13193,7 +14068,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/225.png",
       "large": "https://images.pokemontcg.io/sv3/225_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-226",
@@ -13218,7 +14096,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/226.png",
       "large": "https://images.pokemontcg.io/sv3/226_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-227",
@@ -13243,7 +14124,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/227.png",
       "large": "https://images.pokemontcg.io/sv3/227_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-228",
@@ -13308,7 +14192,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/228.png",
       "large": "https://images.pokemontcg.io/sv3/228_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-229",
@@ -13333,7 +14220,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/229.png",
       "large": "https://images.pokemontcg.io/sv3/229_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3-230",
@@ -13353,6 +14243,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3/230.png",
       "large": "https://images.pokemontcg.io/sv3/230_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv3pt5.json
+++ b/cards/en/sv3pt5.json
@@ -52,7 +52,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/1.png",
       "large": "https://images.pokemontcg.io/sv3pt5/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv3pt5-2",
@@ -120,7 +125,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/2.png",
       "large": "https://images.pokemontcg.io/sv3pt5/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-3",
@@ -186,7 +195,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/3.png",
       "large": "https://images.pokemontcg.io/sv3pt5/3_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-4",
@@ -249,7 +261,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/4.png",
       "large": "https://images.pokemontcg.io/sv3pt5/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "EB Games",
+      "GameStop"
+    ]
   },
   {
     "id": "sv3pt5-5",
@@ -315,7 +333,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/5.png",
       "large": "https://images.pokemontcg.io/sv3pt5/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-6",
@@ -382,7 +404,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/6.png",
       "large": "https://images.pokemontcg.io/sv3pt5/6_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-7",
@@ -445,7 +470,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/7.png",
       "large": "https://images.pokemontcg.io/sv3pt5/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Pokémon Center"
+    ]
   },
   {
     "id": "sv3pt5-8",
@@ -510,7 +540,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/8.png",
       "large": "https://images.pokemontcg.io/sv3pt5/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-9",
@@ -574,7 +608,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/9.png",
       "large": "https://images.pokemontcg.io/sv3pt5/9_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-10",
@@ -627,7 +664,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/10.png",
       "large": "https://images.pokemontcg.io/sv3pt5/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-11",
@@ -693,7 +734,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/11.png",
       "large": "https://images.pokemontcg.io/sv3pt5/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-12",
@@ -754,7 +799,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/12.png",
       "large": "https://images.pokemontcg.io/sv3pt5/12_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-13",
@@ -817,7 +866,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/13.png",
       "large": "https://images.pokemontcg.io/sv3pt5/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-14",
@@ -881,7 +934,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/14.png",
       "large": "https://images.pokemontcg.io/sv3pt5/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-15",
@@ -943,7 +1000,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/15.png",
       "large": "https://images.pokemontcg.io/sv3pt5/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-16",
@@ -1012,7 +1073,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/16.png",
       "large": "https://images.pokemontcg.io/sv3pt5/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-17",
@@ -1068,7 +1133,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/17.png",
       "large": "https://images.pokemontcg.io/sv3pt5/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-18",
@@ -1132,7 +1201,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/18.png",
       "large": "https://images.pokemontcg.io/sv3pt5/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-19",
@@ -1186,7 +1259,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/19.png",
       "large": "https://images.pokemontcg.io/sv3pt5/19_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-20",
@@ -1234,7 +1311,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/20.png",
       "large": "https://images.pokemontcg.io/sv3pt5/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-21",
@@ -1300,7 +1381,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/21.png",
       "large": "https://images.pokemontcg.io/sv3pt5/21_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-22",
@@ -1362,7 +1447,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/22.png",
       "large": "https://images.pokemontcg.io/sv3pt5/22_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-23",
@@ -1417,7 +1506,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/23.png",
       "large": "https://images.pokemontcg.io/sv3pt5/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-24",
@@ -1484,7 +1577,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/24.png",
       "large": "https://images.pokemontcg.io/sv3pt5/24_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-25",
@@ -1548,7 +1644,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/25.png",
       "large": "https://images.pokemontcg.io/sv3pt5/25_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Pokémon Together"
+    ]
   },
   {
     "id": "sv3pt5-26",
@@ -1608,7 +1709,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/26.png",
       "large": "https://images.pokemontcg.io/sv3pt5/26_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-27",
@@ -1669,7 +1774,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/27.png",
       "large": "https://images.pokemontcg.io/sv3pt5/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-28",
@@ -1732,7 +1841,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/28.png",
       "large": "https://images.pokemontcg.io/sv3pt5/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-29",
@@ -1786,7 +1899,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/29.png",
       "large": "https://images.pokemontcg.io/sv3pt5/29_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-30",
@@ -1851,7 +1968,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/30.png",
       "large": "https://images.pokemontcg.io/sv3pt5/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-31",
@@ -1916,7 +2037,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/31.png",
       "large": "https://images.pokemontcg.io/sv3pt5/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-32",
@@ -1969,7 +2094,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/32.png",
       "large": "https://images.pokemontcg.io/sv3pt5/32_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-33",
@@ -2035,7 +2164,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/33.png",
       "large": "https://images.pokemontcg.io/sv3pt5/33_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-34",
@@ -2098,7 +2231,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/34.png",
       "large": "https://images.pokemontcg.io/sv3pt5/34_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-35",
@@ -2161,7 +2298,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/35.png",
       "large": "https://images.pokemontcg.io/sv3pt5/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-36",
@@ -2224,7 +2365,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/36.png",
       "large": "https://images.pokemontcg.io/sv3pt5/36_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-37",
@@ -2278,7 +2423,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/37.png",
       "large": "https://images.pokemontcg.io/sv3pt5/37_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-38",
@@ -2343,7 +2492,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/38.png",
       "large": "https://images.pokemontcg.io/sv3pt5/38_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-39",
@@ -2406,7 +2558,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/39.png",
       "large": "https://images.pokemontcg.io/sv3pt5/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-40",
@@ -2471,7 +2627,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/40.png",
       "large": "https://images.pokemontcg.io/sv3pt5/40_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-41",
@@ -2537,7 +2696,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/41.png",
       "large": "https://images.pokemontcg.io/sv3pt5/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-42",
@@ -2597,7 +2760,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/42.png",
       "large": "https://images.pokemontcg.io/sv3pt5/42_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-43",
@@ -2651,7 +2818,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/43.png",
       "large": "https://images.pokemontcg.io/sv3pt5/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-44",
@@ -2714,7 +2885,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/44.png",
       "large": "https://images.pokemontcg.io/sv3pt5/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-45",
@@ -2775,7 +2950,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/45.png",
       "large": "https://images.pokemontcg.io/sv3pt5/45_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-46",
@@ -2839,7 +3018,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/46.png",
       "large": "https://images.pokemontcg.io/sv3pt5/46_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-47",
@@ -2901,7 +3084,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/47.png",
       "large": "https://images.pokemontcg.io/sv3pt5/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-48",
@@ -2966,7 +3153,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/48.png",
       "large": "https://images.pokemontcg.io/sv3pt5/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-49",
@@ -3028,7 +3219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/49.png",
       "large": "https://images.pokemontcg.io/sv3pt5/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-50",
@@ -3091,7 +3286,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/50.png",
       "large": "https://images.pokemontcg.io/sv3pt5/50_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-51",
@@ -3152,7 +3351,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/51.png",
       "large": "https://images.pokemontcg.io/sv3pt5/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-52",
@@ -3215,7 +3418,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/52.png",
       "large": "https://images.pokemontcg.io/sv3pt5/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-53",
@@ -3275,7 +3482,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/53.png",
       "large": "https://images.pokemontcg.io/sv3pt5/53_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-54",
@@ -3337,7 +3548,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/54.png",
       "large": "https://images.pokemontcg.io/sv3pt5/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-55",
@@ -3399,7 +3614,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/55.png",
       "large": "https://images.pokemontcg.io/sv3pt5/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-56",
@@ -3452,7 +3671,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/56.png",
       "large": "https://images.pokemontcg.io/sv3pt5/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-57",
@@ -3515,7 +3738,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/57.png",
       "large": "https://images.pokemontcg.io/sv3pt5/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-58",
@@ -3569,7 +3796,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/58.png",
       "large": "https://images.pokemontcg.io/sv3pt5/58_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-59",
@@ -3635,7 +3866,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/59.png",
       "large": "https://images.pokemontcg.io/sv3pt5/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-60",
@@ -3688,7 +3923,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/60.png",
       "large": "https://images.pokemontcg.io/sv3pt5/60_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-61",
@@ -3753,7 +3992,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/61.png",
       "large": "https://images.pokemontcg.io/sv3pt5/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-62",
@@ -3816,7 +4059,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/62.png",
       "large": "https://images.pokemontcg.io/sv3pt5/62_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-63",
@@ -3875,7 +4122,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/63.png",
       "large": "https://images.pokemontcg.io/sv3pt5/63_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3pt5-64",
@@ -3935,7 +4187,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/64.png",
       "large": "https://images.pokemontcg.io/sv3pt5/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3pt5-65",
@@ -4006,7 +4263,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/65.png",
       "large": "https://images.pokemontcg.io/sv3pt5/65_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-66",
@@ -4070,7 +4330,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/66.png",
       "large": "https://images.pokemontcg.io/sv3pt5/66_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-67",
@@ -4126,7 +4390,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/67.png",
       "large": "https://images.pokemontcg.io/sv3pt5/67_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-68",
@@ -4186,7 +4454,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/68.png",
       "large": "https://images.pokemontcg.io/sv3pt5/68_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-69",
@@ -4249,7 +4521,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/69.png",
       "large": "https://images.pokemontcg.io/sv3pt5/69_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-70",
@@ -4314,7 +4590,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/70.png",
       "large": "https://images.pokemontcg.io/sv3pt5/70_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-71",
@@ -4377,7 +4657,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/71.png",
       "large": "https://images.pokemontcg.io/sv3pt5/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-72",
@@ -4440,7 +4724,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/72.png",
       "large": "https://images.pokemontcg.io/sv3pt5/72_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-73",
@@ -4504,7 +4792,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/73.png",
       "large": "https://images.pokemontcg.io/sv3pt5/73_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-74",
@@ -4568,7 +4860,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/74.png",
       "large": "https://images.pokemontcg.io/sv3pt5/74_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-75",
@@ -4635,7 +4931,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/75.png",
       "large": "https://images.pokemontcg.io/sv3pt5/75_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-76",
@@ -4703,7 +5003,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/76.png",
       "large": "https://images.pokemontcg.io/sv3pt5/76_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-77",
@@ -4767,7 +5070,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/77.png",
       "large": "https://images.pokemontcg.io/sv3pt5/77_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-78",
@@ -4829,7 +5136,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/78.png",
       "large": "https://images.pokemontcg.io/sv3pt5/78_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-79",
@@ -4900,7 +5211,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/79.png",
       "large": "https://images.pokemontcg.io/sv3pt5/79_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-80",
@@ -4969,7 +5284,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/80.png",
       "large": "https://images.pokemontcg.io/sv3pt5/80_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-81",
@@ -5032,7 +5351,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/81.png",
       "large": "https://images.pokemontcg.io/sv3pt5/81_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-82",
@@ -5098,7 +5421,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/82.png",
       "large": "https://images.pokemontcg.io/sv3pt5/82_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-83",
@@ -5166,7 +5493,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/83.png",
       "large": "https://images.pokemontcg.io/sv3pt5/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-84",
@@ -5225,7 +5556,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/84.png",
       "large": "https://images.pokemontcg.io/sv3pt5/84_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-85",
@@ -5289,7 +5624,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/85.png",
       "large": "https://images.pokemontcg.io/sv3pt5/85_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-86",
@@ -5343,7 +5682,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/86.png",
       "large": "https://images.pokemontcg.io/sv3pt5/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-87",
@@ -5407,7 +5750,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/87.png",
       "large": "https://images.pokemontcg.io/sv3pt5/87_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-88",
@@ -5461,7 +5808,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/88.png",
       "large": "https://images.pokemontcg.io/sv3pt5/88_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-89",
@@ -5527,7 +5878,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/89.png",
       "large": "https://images.pokemontcg.io/sv3pt5/89_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-90",
@@ -5582,7 +5937,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/90.png",
       "large": "https://images.pokemontcg.io/sv3pt5/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-91",
@@ -5636,7 +5995,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/91.png",
       "large": "https://images.pokemontcg.io/sv3pt5/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-92",
@@ -5695,7 +6058,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/92.png",
       "large": "https://images.pokemontcg.io/sv3pt5/92_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-93",
@@ -5763,7 +6130,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/93.png",
       "large": "https://images.pokemontcg.io/sv3pt5/93_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-94",
@@ -5826,7 +6197,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/94.png",
       "large": "https://images.pokemontcg.io/sv3pt5/94_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-95",
@@ -5895,7 +6270,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/95.png",
       "large": "https://images.pokemontcg.io/sv3pt5/95_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-96",
@@ -5956,7 +6335,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/96.png",
       "large": "https://images.pokemontcg.io/sv3pt5/96_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-97",
@@ -6023,7 +6406,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/97.png",
       "large": "https://images.pokemontcg.io/sv3pt5/97_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-98",
@@ -6087,7 +6474,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/98.png",
       "large": "https://images.pokemontcg.io/sv3pt5/98_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-99",
@@ -6154,7 +6545,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/99.png",
       "large": "https://images.pokemontcg.io/sv3pt5/99_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-100",
@@ -6207,7 +6602,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/100.png",
       "large": "https://images.pokemontcg.io/sv3pt5/100_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Professor Program"
+    ]
   },
   {
     "id": "sv3pt5-101",
@@ -6268,7 +6668,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/101.png",
       "large": "https://images.pokemontcg.io/sv3pt5/101_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-102",
@@ -6322,7 +6726,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/102.png",
       "large": "https://images.pokemontcg.io/sv3pt5/102_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-103",
@@ -6387,7 +6795,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/103.png",
       "large": "https://images.pokemontcg.io/sv3pt5/103_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-104",
@@ -6447,7 +6859,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/104.png",
       "large": "https://images.pokemontcg.io/sv3pt5/104_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-105",
@@ -6509,7 +6925,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/105.png",
       "large": "https://images.pokemontcg.io/sv3pt5/105_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-106",
@@ -6571,7 +6991,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/106.png",
       "large": "https://images.pokemontcg.io/sv3pt5/106_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-107",
@@ -6629,7 +7053,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/107.png",
       "large": "https://images.pokemontcg.io/sv3pt5/107_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-108",
@@ -6687,7 +7115,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/108.png",
       "large": "https://images.pokemontcg.io/sv3pt5/108_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-109",
@@ -6741,7 +7173,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/109.png",
       "large": "https://images.pokemontcg.io/sv3pt5/109_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-110",
@@ -6801,7 +7237,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/110.png",
       "large": "https://images.pokemontcg.io/sv3pt5/110_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-111",
@@ -6868,7 +7308,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/111.png",
       "large": "https://images.pokemontcg.io/sv3pt5/111_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-112",
@@ -6937,7 +7381,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/112.png",
       "large": "https://images.pokemontcg.io/sv3pt5/112_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-113",
@@ -7000,7 +7448,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/113.png",
       "large": "https://images.pokemontcg.io/sv3pt5/113_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-114",
@@ -7054,7 +7506,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/114.png",
       "large": "https://images.pokemontcg.io/sv3pt5/114_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-115",
@@ -7119,7 +7575,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/115.png",
       "large": "https://images.pokemontcg.io/sv3pt5/115_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-116",
@@ -7183,7 +7642,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/116.png",
       "large": "https://images.pokemontcg.io/sv3pt5/116_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-117",
@@ -7239,7 +7702,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/117.png",
       "large": "https://images.pokemontcg.io/sv3pt5/117_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-118",
@@ -7302,7 +7769,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/118.png",
       "large": "https://images.pokemontcg.io/sv3pt5/118_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-119",
@@ -7365,7 +7836,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/119.png",
       "large": "https://images.pokemontcg.io/sv3pt5/119_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-120",
@@ -7419,7 +7894,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/120.png",
       "large": "https://images.pokemontcg.io/sv3pt5/120_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-121",
@@ -7478,7 +7957,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/121.png",
       "large": "https://images.pokemontcg.io/sv3pt5/121_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-122",
@@ -7541,7 +8024,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/122.png",
       "large": "https://images.pokemontcg.io/sv3pt5/122_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-123",
@@ -7601,7 +8088,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/123.png",
       "large": "https://images.pokemontcg.io/sv3pt5/123_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-124",
@@ -7668,7 +8159,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/124.png",
       "large": "https://images.pokemontcg.io/sv3pt5/124_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-125",
@@ -7732,7 +8226,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/125.png",
       "large": "https://images.pokemontcg.io/sv3pt5/125_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv3pt5-126",
@@ -7797,7 +8296,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/126.png",
       "large": "https://images.pokemontcg.io/sv3pt5/126_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-127",
@@ -7860,7 +8363,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/127.png",
       "large": "https://images.pokemontcg.io/sv3pt5/127_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-128",
@@ -7921,7 +8428,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/128.png",
       "large": "https://images.pokemontcg.io/sv3pt5/128_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-129",
@@ -7974,7 +8485,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/129.png",
       "large": "https://images.pokemontcg.io/sv3pt5/129_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-130",
@@ -8038,7 +8553,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/130.png",
       "large": "https://images.pokemontcg.io/sv3pt5/130_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-131",
@@ -8099,7 +8618,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/131.png",
       "large": "https://images.pokemontcg.io/sv3pt5/131_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-132",
@@ -8156,7 +8679,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/132.png",
       "large": "https://images.pokemontcg.io/sv3pt5/132_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-133",
@@ -8225,7 +8752,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/133.png",
       "large": "https://images.pokemontcg.io/sv3pt5/133_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Pokémon Together"
+    ]
   },
   {
     "id": "sv3pt5-134",
@@ -8288,7 +8820,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/134.png",
       "large": "https://images.pokemontcg.io/sv3pt5/134_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-135",
@@ -8346,7 +8882,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/135.png",
       "large": "https://images.pokemontcg.io/sv3pt5/135_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-136",
@@ -8409,7 +8949,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/136.png",
       "large": "https://images.pokemontcg.io/sv3pt5/136_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-137",
@@ -8462,7 +9006,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/137.png",
       "large": "https://images.pokemontcg.io/sv3pt5/137_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-138",
@@ -8518,7 +9066,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/138.png",
       "large": "https://images.pokemontcg.io/sv3pt5/138_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-139",
@@ -8579,7 +9131,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/139.png",
       "large": "https://images.pokemontcg.io/sv3pt5/139_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-140",
@@ -8635,7 +9191,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/140.png",
       "large": "https://images.pokemontcg.io/sv3pt5/140_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-141",
@@ -8696,7 +9256,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/141.png",
       "large": "https://images.pokemontcg.io/sv3pt5/141_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-142",
@@ -8759,7 +9323,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/142.png",
       "large": "https://images.pokemontcg.io/sv3pt5/142_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-143",
@@ -8821,7 +9389,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/143.png",
       "large": "https://images.pokemontcg.io/sv3pt5/143_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-144",
@@ -8887,7 +9459,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/144.png",
       "large": "https://images.pokemontcg.io/sv3pt5/144_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-145",
@@ -8956,7 +9532,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/145.png",
       "large": "https://images.pokemontcg.io/sv3pt5/145_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-146",
@@ -9022,7 +9601,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/146.png",
       "large": "https://images.pokemontcg.io/sv3pt5/146_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-147",
@@ -9079,7 +9662,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/147.png",
       "large": "https://images.pokemontcg.io/sv3pt5/147_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-148",
@@ -9138,7 +9725,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/148.png",
       "large": "https://images.pokemontcg.io/sv3pt5/148_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-149",
@@ -9193,7 +9784,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/149.png",
       "large": "https://images.pokemontcg.io/sv3pt5/149_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-150",
@@ -9262,7 +9857,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/150.png",
       "large": "https://images.pokemontcg.io/sv3pt5/150_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-151",
@@ -9326,7 +9925,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/151.png",
       "large": "https://images.pokemontcg.io/sv3pt5/151_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-152",
@@ -9359,7 +9961,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/152.png",
       "large": "https://images.pokemontcg.io/sv3pt5/152_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-153",
@@ -9392,7 +9998,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/153.png",
       "large": "https://images.pokemontcg.io/sv3pt5/153_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-154",
@@ -9425,7 +10035,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/154.png",
       "large": "https://images.pokemontcg.io/sv3pt5/154_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-155",
@@ -9450,7 +10064,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/155.png",
       "large": "https://images.pokemontcg.io/sv3pt5/155_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-156",
@@ -9475,7 +10093,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/156.png",
       "large": "https://images.pokemontcg.io/sv3pt5/156_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-157",
@@ -9500,7 +10122,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/157.png",
       "large": "https://images.pokemontcg.io/sv3pt5/157_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-158",
@@ -9525,7 +10151,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/158.png",
       "large": "https://images.pokemontcg.io/sv3pt5/158_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-159",
@@ -9550,7 +10180,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/159.png",
       "large": "https://images.pokemontcg.io/sv3pt5/159_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-160",
@@ -9575,7 +10209,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/160.png",
       "large": "https://images.pokemontcg.io/sv3pt5/160_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-161",
@@ -9600,7 +10238,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/161.png",
       "large": "https://images.pokemontcg.io/sv3pt5/161_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-162",
@@ -9625,7 +10267,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/162.png",
       "large": "https://images.pokemontcg.io/sv3pt5/162_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-163",
@@ -9650,7 +10296,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/163.png",
       "large": "https://images.pokemontcg.io/sv3pt5/163_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-164",
@@ -9675,7 +10325,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/164.png",
       "large": "https://images.pokemontcg.io/sv3pt5/164_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-165",
@@ -9700,7 +10354,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/165.png",
       "large": "https://images.pokemontcg.io/sv3pt5/165_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv3pt5-166",
@@ -9755,7 +10413,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/166.png",
       "large": "https://images.pokemontcg.io/sv3pt5/166_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-167",
@@ -9823,7 +10484,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/167.png",
       "large": "https://images.pokemontcg.io/sv3pt5/167_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-168",
@@ -9886,7 +10550,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/168.png",
       "large": "https://images.pokemontcg.io/sv3pt5/168_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-169",
@@ -9952,7 +10619,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/169.png",
       "large": "https://images.pokemontcg.io/sv3pt5/169_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-170",
@@ -10015,7 +10685,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/170.png",
       "large": "https://images.pokemontcg.io/sv3pt5/170_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-171",
@@ -10080,7 +10753,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/171.png",
       "large": "https://images.pokemontcg.io/sv3pt5/171_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-172",
@@ -10133,7 +10809,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/172.png",
       "large": "https://images.pokemontcg.io/sv3pt5/172_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-173",
@@ -10197,7 +10876,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/173.png",
       "large": "https://images.pokemontcg.io/sv3pt5/173_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-174",
@@ -10260,7 +10942,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/174.png",
       "large": "https://images.pokemontcg.io/sv3pt5/174_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-175",
@@ -10322,7 +11007,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/175.png",
       "large": "https://images.pokemontcg.io/sv3pt5/175_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-176",
@@ -10387,7 +11075,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/176.png",
       "large": "https://images.pokemontcg.io/sv3pt5/176_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-177",
@@ -10443,7 +11134,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/177.png",
       "large": "https://images.pokemontcg.io/sv3pt5/177_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-178",
@@ -10497,7 +11191,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/178.png",
       "large": "https://images.pokemontcg.io/sv3pt5/178_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-179",
@@ -10560,7 +11257,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/179.png",
       "large": "https://images.pokemontcg.io/sv3pt5/179_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-180",
@@ -10616,7 +11316,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/180.png",
       "large": "https://images.pokemontcg.io/sv3pt5/180_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-181",
@@ -10675,7 +11378,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/181.png",
       "large": "https://images.pokemontcg.io/sv3pt5/181_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-182",
@@ -10741,7 +11447,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/182.png",
       "large": "https://images.pokemontcg.io/sv3pt5/182_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-183",
@@ -10808,7 +11517,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/183.png",
       "large": "https://images.pokemontcg.io/sv3pt5/183_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-184",
@@ -10872,7 +11584,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/184.png",
       "large": "https://images.pokemontcg.io/sv3pt5/184_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-185",
@@ -10939,7 +11654,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/185.png",
       "large": "https://images.pokemontcg.io/sv3pt5/185_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-186",
@@ -11004,7 +11722,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/186.png",
       "large": "https://images.pokemontcg.io/sv3pt5/186_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-187",
@@ -11069,7 +11790,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/187.png",
       "large": "https://images.pokemontcg.io/sv3pt5/187_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-188",
@@ -11140,7 +11864,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/188.png",
       "large": "https://images.pokemontcg.io/sv3pt5/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-189",
@@ -11208,7 +11935,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/189.png",
       "large": "https://images.pokemontcg.io/sv3pt5/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-190",
@@ -11273,7 +12003,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/190.png",
       "large": "https://images.pokemontcg.io/sv3pt5/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-191",
@@ -11340,7 +12073,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/191.png",
       "large": "https://images.pokemontcg.io/sv3pt5/191_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-192",
@@ -11409,7 +12145,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/192.png",
       "large": "https://images.pokemontcg.io/sv3pt5/192_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-193",
@@ -11473,7 +12212,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/193.png",
       "large": "https://images.pokemontcg.io/sv3pt5/193_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-194",
@@ -11498,7 +12240,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/194.png",
       "large": "https://images.pokemontcg.io/sv3pt5/194_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-195",
@@ -11523,7 +12268,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/195.png",
       "large": "https://images.pokemontcg.io/sv3pt5/195_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-196",
@@ -11548,7 +12296,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/196.png",
       "large": "https://images.pokemontcg.io/sv3pt5/196_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-197",
@@ -11573,7 +12324,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/197.png",
       "large": "https://images.pokemontcg.io/sv3pt5/197_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-198",
@@ -11639,7 +12393,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/198.png",
       "large": "https://images.pokemontcg.io/sv3pt5/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-199",
@@ -11706,7 +12463,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/199.png",
       "large": "https://images.pokemontcg.io/sv3pt5/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-200",
@@ -11770,7 +12530,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/200.png",
       "large": "https://images.pokemontcg.io/sv3pt5/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-201",
@@ -11841,7 +12604,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/201.png",
       "large": "https://images.pokemontcg.io/sv3pt5/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-202",
@@ -11910,7 +12676,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/202.png",
       "large": "https://images.pokemontcg.io/sv3pt5/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-203",
@@ -11935,7 +12704,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/203.png",
       "large": "https://images.pokemontcg.io/sv3pt5/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-204",
@@ -11960,7 +12732,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/204.png",
       "large": "https://images.pokemontcg.io/sv3pt5/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-205",
@@ -12024,7 +12799,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/205.png",
       "large": "https://images.pokemontcg.io/sv3pt5/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo",
+      "Metal Card"
+    ]
   },
   {
     "id": "sv3pt5-206",
@@ -12049,7 +12829,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/206.png",
       "large": "https://images.pokemontcg.io/sv3pt5/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv3pt5-207",
@@ -12071,6 +12854,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv3pt5/207.png",
       "large": "https://images.pokemontcg.io/sv3pt5/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv4.json
+++ b/cards/en/sv4.json
@@ -50,7 +50,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/1.png",
       "large": "https://images.pokemontcg.io/sv4/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-2",
@@ -111,7 +115,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/2.png",
       "large": "https://images.pokemontcg.io/sv4/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-3",
@@ -175,7 +183,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/3.png",
       "large": "https://images.pokemontcg.io/sv4/3_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-4",
@@ -239,7 +250,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/4.png",
       "large": "https://images.pokemontcg.io/sv4/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-5",
@@ -299,7 +314,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/5.png",
       "large": "https://images.pokemontcg.io/sv4/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-6",
@@ -353,7 +372,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/6.png",
       "large": "https://images.pokemontcg.io/sv4/6_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-7",
@@ -418,7 +441,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/7.png",
       "large": "https://images.pokemontcg.io/sv4/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-8",
@@ -471,7 +498,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/8.png",
       "large": "https://images.pokemontcg.io/sv4/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-9",
@@ -536,7 +567,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/9.png",
       "large": "https://images.pokemontcg.io/sv4/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-10",
@@ -589,7 +624,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/10.png",
       "large": "https://images.pokemontcg.io/sv4/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-11",
@@ -654,7 +693,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/11.png",
       "large": "https://images.pokemontcg.io/sv4/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-12",
@@ -715,7 +758,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/12.png",
       "large": "https://images.pokemontcg.io/sv4/12_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-13",
@@ -761,7 +808,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/13.png",
       "large": "https://images.pokemontcg.io/sv4/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-14",
@@ -812,7 +863,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/14.png",
       "large": "https://images.pokemontcg.io/sv4/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-15",
@@ -872,7 +927,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/15.png",
       "large": "https://images.pokemontcg.io/sv4/15_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-16",
@@ -934,7 +993,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/16.png",
       "large": "https://images.pokemontcg.io/sv4/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-17",
@@ -995,7 +1058,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/17.png",
       "large": "https://images.pokemontcg.io/sv4/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-18",
@@ -1059,7 +1126,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/18.png",
       "large": "https://images.pokemontcg.io/sv4/18_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-19",
@@ -1078,8 +1149,7 @@
     "attacks": [
       {
         "name": "Scorching Heater",
-        "cost": [
-        ],
+        "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if it is Knocked Out), put 6 damage counters on the Attacking Pokémon."
@@ -1107,7 +1177,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/19.png",
       "large": "https://images.pokemontcg.io/sv4/19_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-20",
@@ -1171,7 +1245,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/20.png",
       "large": "https://images.pokemontcg.io/sv4/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-21",
@@ -1232,7 +1310,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/21.png",
       "large": "https://images.pokemontcg.io/sv4/21_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-22",
@@ -1295,7 +1377,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/22.png",
       "large": "https://images.pokemontcg.io/sv4/22_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-23",
@@ -1356,7 +1442,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/23.png",
       "large": "https://images.pokemontcg.io/sv4/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-24",
@@ -1410,7 +1500,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/24.png",
       "large": "https://images.pokemontcg.io/sv4/24_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-25",
@@ -1470,7 +1564,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/25.png",
       "large": "https://images.pokemontcg.io/sv4/25_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-26",
@@ -1532,7 +1630,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/26.png",
       "large": "https://images.pokemontcg.io/sv4/26_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-27",
@@ -1595,7 +1698,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/27.png",
       "large": "https://images.pokemontcg.io/sv4/27_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-28",
@@ -1656,7 +1762,16 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/28.png",
       "large": "https://images.pokemontcg.io/sv4/28_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "EB Games",
+      "GameStop",
+      "Normal",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv4-29",
@@ -1716,7 +1831,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/29.png",
       "large": "https://images.pokemontcg.io/sv4/29_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-30",
@@ -1769,7 +1889,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/30.png",
       "large": "https://images.pokemontcg.io/sv4/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-31",
@@ -1824,7 +1948,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/31.png",
       "large": "https://images.pokemontcg.io/sv4/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-32",
@@ -1885,7 +2013,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/32.png",
       "large": "https://images.pokemontcg.io/sv4/32_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-33",
@@ -1938,7 +2071,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/33.png",
       "large": "https://images.pokemontcg.io/sv4/33_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-34",
@@ -1998,7 +2135,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/34.png",
       "large": "https://images.pokemontcg.io/sv4/34_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-35",
@@ -2051,7 +2192,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/35.png",
       "large": "https://images.pokemontcg.io/sv4/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-36",
@@ -2111,7 +2256,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/36.png",
       "large": "https://images.pokemontcg.io/sv4/36_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-37",
@@ -2165,7 +2314,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/37.png",
       "large": "https://images.pokemontcg.io/sv4/37_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-38",
@@ -2227,7 +2380,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/38.png",
       "large": "https://images.pokemontcg.io/sv4/38_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo"
+    ]
   },
   {
     "id": "sv4-39",
@@ -2246,8 +2403,7 @@
     "attacks": [
       {
         "name": "Buoyant Healing",
-        "cost": [
-        ],
+        "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "Heal 120 damage from 1 of your Benched Pokémon."
@@ -2275,7 +2431,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/39.png",
       "large": "https://images.pokemontcg.io/sv4/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-40",
@@ -2338,7 +2498,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/40.png",
       "large": "https://images.pokemontcg.io/sv4/40_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-41",
@@ -2402,7 +2566,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/41.png",
       "large": "https://images.pokemontcg.io/sv4/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-42",
@@ -2462,7 +2630,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/42.png",
       "large": "https://images.pokemontcg.io/sv4/42_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-43",
@@ -2516,7 +2688,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/43.png",
       "large": "https://images.pokemontcg.io/sv4/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-44",
@@ -2572,7 +2748,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/44.png",
       "large": "https://images.pokemontcg.io/sv4/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-45",
@@ -2632,7 +2812,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/45.png",
       "large": "https://images.pokemontcg.io/sv4/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-46",
@@ -2699,7 +2883,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/46.png",
       "large": "https://images.pokemontcg.io/sv4/46_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-47",
@@ -2763,7 +2950,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/47.png",
       "large": "https://images.pokemontcg.io/sv4/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-48",
@@ -2828,7 +3019,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/48.png",
       "large": "https://images.pokemontcg.io/sv4/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-49",
@@ -2891,7 +3086,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/49.png",
       "large": "https://images.pokemontcg.io/sv4/49_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-50",
@@ -2959,7 +3159,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/50.png",
       "large": "https://images.pokemontcg.io/sv4/50_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-51",
@@ -3009,7 +3212,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/51.png",
       "large": "https://images.pokemontcg.io/sv4/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-52",
@@ -3060,7 +3267,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/52.png",
       "large": "https://images.pokemontcg.io/sv4/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-53",
@@ -3120,7 +3331,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/53.png",
       "large": "https://images.pokemontcg.io/sv4/53_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-54",
@@ -3180,7 +3395,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/54.png",
       "large": "https://images.pokemontcg.io/sv4/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-55",
@@ -3246,7 +3465,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/55.png",
       "large": "https://images.pokemontcg.io/sv4/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-56",
@@ -3306,7 +3529,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/56.png",
       "large": "https://images.pokemontcg.io/sv4/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-57",
@@ -3367,7 +3594,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/57.png",
       "large": "https://images.pokemontcg.io/sv4/57_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-58",
@@ -3433,7 +3664,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/58.png",
       "large": "https://images.pokemontcg.io/sv4/58_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-59",
@@ -3452,8 +3686,7 @@
     "attacks": [
       {
         "name": "Crackling Shot",
-        "cost": [
-        ],
+        "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
@@ -3481,7 +3714,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/59.png",
       "large": "https://images.pokemontcg.io/sv4/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-60",
@@ -3532,7 +3769,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/60.png",
       "large": "https://images.pokemontcg.io/sv4/60_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-61",
@@ -3589,7 +3830,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/61.png",
       "large": "https://images.pokemontcg.io/sv4/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-62",
@@ -3653,7 +3898,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/62.png",
       "large": "https://images.pokemontcg.io/sv4/62_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-63",
@@ -3715,7 +3964,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/63.png",
       "large": "https://images.pokemontcg.io/sv4/63_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-64",
@@ -3768,7 +4021,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/64.png",
       "large": "https://images.pokemontcg.io/sv4/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-65",
@@ -3819,7 +4076,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/65.png",
       "large": "https://images.pokemontcg.io/sv4/65_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-66",
@@ -3881,7 +4142,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/66.png",
       "large": "https://images.pokemontcg.io/sv4/66_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-67",
@@ -3941,7 +4206,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/67.png",
       "large": "https://images.pokemontcg.io/sv4/67_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-68",
@@ -4006,7 +4275,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/68.png",
       "large": "https://images.pokemontcg.io/sv4/68_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-69",
@@ -4061,7 +4333,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/69.png",
       "large": "https://images.pokemontcg.io/sv4/69_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-70",
@@ -4132,7 +4408,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/70.png",
       "large": "https://images.pokemontcg.io/sv4/70_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-71",
@@ -4191,7 +4470,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/71.png",
       "large": "https://images.pokemontcg.io/sv4/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-72",
@@ -4257,7 +4540,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/72.png",
       "large": "https://images.pokemontcg.io/sv4/72_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-73",
@@ -4324,7 +4612,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/73.png",
       "large": "https://images.pokemontcg.io/sv4/73_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-74",
@@ -4391,7 +4683,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/74.png",
       "large": "https://images.pokemontcg.io/sv4/74_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-75",
@@ -4452,7 +4748,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/75.png",
       "large": "https://images.pokemontcg.io/sv4/75_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-76",
@@ -4521,7 +4821,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/76.png",
       "large": "https://images.pokemontcg.io/sv4/76_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-77",
@@ -4591,7 +4894,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/77.png",
       "large": "https://images.pokemontcg.io/sv4/77_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-78",
@@ -4658,7 +4965,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/78.png",
       "large": "https://images.pokemontcg.io/sv4/78_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-79",
@@ -4714,7 +5025,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/79.png",
       "large": "https://images.pokemontcg.io/sv4/79_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-80",
@@ -4771,7 +5086,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/80.png",
       "large": "https://images.pokemontcg.io/sv4/80_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-81",
@@ -4836,7 +5155,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/81.png",
       "large": "https://images.pokemontcg.io/sv4/81_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-82",
@@ -4895,7 +5219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/82.png",
       "large": "https://images.pokemontcg.io/sv4/82_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-83",
@@ -4946,7 +5274,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/83.png",
       "large": "https://images.pokemontcg.io/sv4/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-84",
@@ -4998,7 +5330,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/84.png",
       "large": "https://images.pokemontcg.io/sv4/84_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-85",
@@ -5059,7 +5395,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/85.png",
       "large": "https://images.pokemontcg.io/sv4/85_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-86",
@@ -5126,7 +5466,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/86.png",
       "large": "https://images.pokemontcg.io/sv4/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-87",
@@ -5192,7 +5536,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/87.png",
       "large": "https://images.pokemontcg.io/sv4/87_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-88",
@@ -5249,7 +5597,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/88.png",
       "large": "https://images.pokemontcg.io/sv4/88_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-89",
@@ -5313,7 +5665,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/89.png",
       "large": "https://images.pokemontcg.io/sv4/89_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-90",
@@ -5380,7 +5735,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/90.png",
       "large": "https://images.pokemontcg.io/sv4/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-91",
@@ -5433,7 +5792,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/91.png",
       "large": "https://images.pokemontcg.io/sv4/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-92",
@@ -5496,7 +5859,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/92.png",
       "large": "https://images.pokemontcg.io/sv4/92_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-93",
@@ -5559,7 +5926,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/93.png",
       "large": "https://images.pokemontcg.io/sv4/93_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-94",
@@ -5612,7 +5983,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/94.png",
       "large": "https://images.pokemontcg.io/sv4/94_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-95",
@@ -5666,7 +6041,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/95.png",
       "large": "https://images.pokemontcg.io/sv4/95_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-96",
@@ -5729,7 +6108,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/96.png",
       "large": "https://images.pokemontcg.io/sv4/96_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-97",
@@ -5790,7 +6173,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/97.png",
       "large": "https://images.pokemontcg.io/sv4/97_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-98",
@@ -5858,7 +6245,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/98.png",
       "large": "https://images.pokemontcg.io/sv4/98_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-99",
@@ -5916,7 +6306,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/99.png",
       "large": "https://images.pokemontcg.io/sv4/99_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-100",
@@ -5985,7 +6379,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/100.png",
       "large": "https://images.pokemontcg.io/sv4/100_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-101",
@@ -6046,7 +6443,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/101.png",
       "large": "https://images.pokemontcg.io/sv4/101_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-102",
@@ -6098,7 +6499,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/102.png",
       "large": "https://images.pokemontcg.io/sv4/102_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-103",
@@ -6152,7 +6557,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/103.png",
       "large": "https://images.pokemontcg.io/sv4/103_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-104",
@@ -6215,7 +6624,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/104.png",
       "large": "https://images.pokemontcg.io/sv4/104_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-105",
@@ -6278,7 +6691,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/105.png",
       "large": "https://images.pokemontcg.io/sv4/105_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-106",
@@ -6344,7 +6761,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/106.png",
       "large": "https://images.pokemontcg.io/sv4/106_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-107",
@@ -6407,7 +6828,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/107.png",
       "large": "https://images.pokemontcg.io/sv4/107_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv4-108",
@@ -6471,7 +6897,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/108.png",
       "large": "https://images.pokemontcg.io/sv4/108_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-109",
@@ -6535,7 +6964,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/109.png",
       "large": "https://images.pokemontcg.io/sv4/109_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-110",
@@ -6604,7 +7037,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/110.png",
       "large": "https://images.pokemontcg.io/sv4/110_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-111",
@@ -6665,7 +7102,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/111.png",
       "large": "https://images.pokemontcg.io/sv4/111_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-112",
@@ -6730,7 +7171,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/112.png",
       "large": "https://images.pokemontcg.io/sv4/112_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-113",
@@ -6790,7 +7235,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/113.png",
       "large": "https://images.pokemontcg.io/sv4/113_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-114",
@@ -6853,7 +7302,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/114.png",
       "large": "https://images.pokemontcg.io/sv4/114_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-115",
@@ -6914,7 +7367,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/115.png",
       "large": "https://images.pokemontcg.io/sv4/115_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-116",
@@ -6979,7 +7436,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/116.png",
       "large": "https://images.pokemontcg.io/sv4/116_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-117",
@@ -7043,7 +7504,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/117.png",
       "large": "https://images.pokemontcg.io/sv4/117_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-118",
@@ -7112,7 +7577,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/118.png",
       "large": "https://images.pokemontcg.io/sv4/118_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-119",
@@ -7165,7 +7634,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/119.png",
       "large": "https://images.pokemontcg.io/sv4/119_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-120",
@@ -7224,7 +7697,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/120.png",
       "large": "https://images.pokemontcg.io/sv4/120_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-121",
@@ -7282,7 +7759,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/121.png",
       "large": "https://images.pokemontcg.io/sv4/121_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-122",
@@ -7343,7 +7825,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/122.png",
       "large": "https://images.pokemontcg.io/sv4/122_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-123",
@@ -7405,7 +7893,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/123.png",
       "large": "https://images.pokemontcg.io/sv4/123_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-124",
@@ -7473,7 +7966,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/124.png",
       "large": "https://images.pokemontcg.io/sv4/124_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-125",
@@ -7546,7 +8042,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/125.png",
       "large": "https://images.pokemontcg.io/sv4/125_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-126",
@@ -7609,7 +8110,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/126.png",
       "large": "https://images.pokemontcg.io/sv4/126_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-127",
@@ -7670,7 +8175,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/127.png",
       "large": "https://images.pokemontcg.io/sv4/127_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-128",
@@ -7737,7 +8246,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/128.png",
       "large": "https://images.pokemontcg.io/sv4/128_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-129",
@@ -7805,7 +8318,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/129.png",
       "large": "https://images.pokemontcg.io/sv4/129_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-130",
@@ -7864,7 +8381,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/130.png",
       "large": "https://images.pokemontcg.io/sv4/130_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-131",
@@ -7923,7 +8444,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/131.png",
       "large": "https://images.pokemontcg.io/sv4/131_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-132",
@@ -7994,7 +8519,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/132.png",
       "large": "https://images.pokemontcg.io/sv4/132_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-133",
@@ -8065,7 +8594,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/133.png",
       "large": "https://images.pokemontcg.io/sv4/133_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-134",
@@ -8132,7 +8665,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/134.png",
       "large": "https://images.pokemontcg.io/sv4/134_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-135",
@@ -8204,7 +8742,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/135.png",
       "large": "https://images.pokemontcg.io/sv4/135_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-136",
@@ -8272,7 +8813,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/136.png",
       "large": "https://images.pokemontcg.io/sv4/136_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv4-137",
@@ -8344,7 +8890,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/137.png",
       "large": "https://images.pokemontcg.io/sv4/137_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-138",
@@ -8413,7 +8962,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/138.png",
       "large": "https://images.pokemontcg.io/sv4/138_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-139",
@@ -8481,7 +9034,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/139.png",
       "large": "https://images.pokemontcg.io/sv4/139_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-140",
@@ -8537,7 +9093,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/140.png",
       "large": "https://images.pokemontcg.io/sv4/140_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-141",
@@ -8591,7 +9150,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/141.png",
       "large": "https://images.pokemontcg.io/sv4/141_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-142",
@@ -8644,7 +9207,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/142.png",
       "large": "https://images.pokemontcg.io/sv4/142_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-143",
@@ -8698,7 +9265,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/143.png",
       "large": "https://images.pokemontcg.io/sv4/143_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-144",
@@ -8757,7 +9328,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/144.png",
       "large": "https://images.pokemontcg.io/sv4/144_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-145",
@@ -8820,7 +9396,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/145.png",
       "large": "https://images.pokemontcg.io/sv4/145_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-146",
@@ -8882,7 +9462,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/146.png",
       "large": "https://images.pokemontcg.io/sv4/146_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-147",
@@ -8934,7 +9518,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/147.png",
       "large": "https://images.pokemontcg.io/sv4/147_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-148",
@@ -8988,7 +9576,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/148.png",
       "large": "https://images.pokemontcg.io/sv4/148_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-149",
@@ -9053,7 +9645,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/149.png",
       "large": "https://images.pokemontcg.io/sv4/149_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-150",
@@ -9117,7 +9713,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/150.png",
       "large": "https://images.pokemontcg.io/sv4/150_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-151",
@@ -9176,7 +9776,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/151.png",
       "large": "https://images.pokemontcg.io/sv4/151_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-152",
@@ -9245,7 +9849,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/152.png",
       "large": "https://images.pokemontcg.io/sv4/152_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-153",
@@ -9291,7 +9899,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/153.png",
       "large": "https://images.pokemontcg.io/sv4/153_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-154",
@@ -9342,7 +9954,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/154.png",
       "large": "https://images.pokemontcg.io/sv4/154_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-155",
@@ -9400,7 +10016,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/155.png",
       "large": "https://images.pokemontcg.io/sv4/155_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-156",
@@ -9470,7 +10089,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/156.png",
       "large": "https://images.pokemontcg.io/sv4/156_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-157",
@@ -9531,7 +10153,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/157.png",
       "large": "https://images.pokemontcg.io/sv4/157_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-158",
@@ -9604,7 +10230,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/158.png",
       "large": "https://images.pokemontcg.io/sv4/158_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-159",
@@ -9630,7 +10261,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/159.png",
       "large": "https://images.pokemontcg.io/sv4/159_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-160",
@@ -9655,7 +10291,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/160.png",
       "large": "https://images.pokemontcg.io/sv4/160_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-161",
@@ -9680,7 +10320,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/161.png",
       "large": "https://images.pokemontcg.io/sv4/161_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-162",
@@ -9705,7 +10349,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/162.png",
       "large": "https://images.pokemontcg.io/sv4/162_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-163",
@@ -9731,7 +10379,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/163.png",
       "large": "https://images.pokemontcg.io/sv4/163_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-164",
@@ -9757,7 +10409,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/164.png",
       "large": "https://images.pokemontcg.io/sv4/164_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv4-165",
@@ -9782,7 +10439,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/165.png",
       "large": "https://images.pokemontcg.io/sv4/165_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-166",
@@ -9807,7 +10468,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/166.png",
       "large": "https://images.pokemontcg.io/sv4/166_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-167",
@@ -9832,7 +10497,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/167.png",
       "large": "https://images.pokemontcg.io/sv4/167_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-168",
@@ -9857,7 +10526,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/168.png",
       "large": "https://images.pokemontcg.io/sv4/168_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-169",
@@ -9882,7 +10555,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/169.png",
       "large": "https://images.pokemontcg.io/sv4/169_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-170",
@@ -9908,7 +10585,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/170.png",
       "large": "https://images.pokemontcg.io/sv4/170_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Professor Program"
+    ]
   },
   {
     "id": "sv4-171",
@@ -9934,7 +10616,14 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/171.png",
       "large": "https://images.pokemontcg.io/sv4/171_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Professor Program",
+      "Regional Championship",
+      "Regional Championship (Staff)"
+    ]
   },
   {
     "id": "sv4-172",
@@ -9959,7 +10648,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/172.png",
       "large": "https://images.pokemontcg.io/sv4/172_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-173",
@@ -9984,7 +10677,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/173.png",
       "large": "https://images.pokemontcg.io/sv4/173_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-174",
@@ -10009,7 +10706,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/174.png",
       "large": "https://images.pokemontcg.io/sv4/174_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-175",
@@ -10035,7 +10736,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/175.png",
       "large": "https://images.pokemontcg.io/sv4/175_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-176",
@@ -10073,7 +10778,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/176.png",
       "large": "https://images.pokemontcg.io/sv4/176_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-177",
@@ -10109,7 +10818,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/177.png",
       "large": "https://images.pokemontcg.io/sv4/177_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-178",
@@ -10145,7 +10858,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/178.png",
       "large": "https://images.pokemontcg.io/sv4/178_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv4-179",
@@ -10181,7 +10899,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/179.png",
       "large": "https://images.pokemontcg.io/sv4/179_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-180",
@@ -10207,7 +10929,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/180.png",
       "large": "https://images.pokemontcg.io/sv4/180_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-181",
@@ -10232,7 +10958,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/181.png",
       "large": "https://images.pokemontcg.io/sv4/181_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-182",
@@ -10255,7 +10985,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/182.png",
       "large": "https://images.pokemontcg.io/sv4/182_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4-183",
@@ -10320,7 +11054,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/183.png",
       "large": "https://images.pokemontcg.io/sv4/183_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-184",
@@ -10385,7 +11122,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/184.png",
       "large": "https://images.pokemontcg.io/sv4/184_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-185",
@@ -10446,7 +11186,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/185.png",
       "large": "https://images.pokemontcg.io/sv4/185_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-186",
@@ -10465,8 +11208,7 @@
     "attacks": [
       {
         "name": "Scorching Heater",
-        "cost": [
-        ],
+        "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "During your opponent's next turn, if this Pokémon is damaged by an attack (even if it is Knocked Out), put 6 damage counters on the Attacking Pokémon."
@@ -10494,7 +11236,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/186.png",
       "large": "https://images.pokemontcg.io/sv4/186_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-187",
@@ -10555,7 +11300,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/187.png",
       "large": "https://images.pokemontcg.io/sv4/187_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-188",
@@ -10609,7 +11357,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/188.png",
       "large": "https://images.pokemontcg.io/sv4/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-189",
@@ -10628,8 +11379,7 @@
     "attacks": [
       {
         "name": "Buoyant Healing",
-        "cost": [
-        ],
+        "cost": [],
         "convertedEnergyCost": 0,
         "damage": "",
         "text": "Heal 120 damage from 1 of your Benched Pokémon."
@@ -10657,7 +11407,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/189.png",
       "large": "https://images.pokemontcg.io/sv4/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-190",
@@ -10713,7 +11466,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/190.png",
       "large": "https://images.pokemontcg.io/sv4/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-191",
@@ -10778,7 +11534,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/191.png",
       "large": "https://images.pokemontcg.io/sv4/191_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-192",
@@ -10838,7 +11597,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/192.png",
       "large": "https://images.pokemontcg.io/sv4/192_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-193",
@@ -10889,7 +11651,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/193.png",
       "large": "https://images.pokemontcg.io/sv4/193_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-194",
@@ -10946,7 +11711,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/194.png",
       "large": "https://images.pokemontcg.io/sv4/194_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-195",
@@ -11010,7 +11778,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/195.png",
       "large": "https://images.pokemontcg.io/sv4/195_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-196",
@@ -11063,7 +11834,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/196.png",
       "large": "https://images.pokemontcg.io/sv4/196_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-197",
@@ -11128,7 +11902,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/197.png",
       "large": "https://images.pokemontcg.io/sv4/197_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-198",
@@ -11185,7 +11962,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/198.png",
       "large": "https://images.pokemontcg.io/sv4/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-199",
@@ -11248,7 +12028,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/199.png",
       "large": "https://images.pokemontcg.io/sv4/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-200",
@@ -11309,7 +12092,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/200.png",
       "large": "https://images.pokemontcg.io/sv4/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-201",
@@ -11367,7 +12153,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/201.png",
       "large": "https://images.pokemontcg.io/sv4/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-202",
@@ -11430,7 +12219,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/202.png",
       "large": "https://images.pokemontcg.io/sv4/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-203",
@@ -11493,7 +12285,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/203.png",
       "large": "https://images.pokemontcg.io/sv4/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-204",
@@ -11557,7 +12352,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/204.png",
       "large": "https://images.pokemontcg.io/sv4/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-205",
@@ -11626,7 +12424,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/205.png",
       "large": "https://images.pokemontcg.io/sv4/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-206",
@@ -11684,7 +12485,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/206.png",
       "large": "https://images.pokemontcg.io/sv4/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-207",
@@ -11746,7 +12550,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/207.png",
       "large": "https://images.pokemontcg.io/sv4/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-208",
@@ -11819,7 +12626,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/208.png",
       "large": "https://images.pokemontcg.io/sv4/208_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-209",
@@ -11886,7 +12696,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/209.png",
       "large": "https://images.pokemontcg.io/sv4/209_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-210",
@@ -11953,7 +12766,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/210.png",
       "large": "https://images.pokemontcg.io/sv4/210_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-211",
@@ -12016,7 +12832,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/211.png",
       "large": "https://images.pokemontcg.io/sv4/211_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-212",
@@ -12081,7 +12900,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/212.png",
       "large": "https://images.pokemontcg.io/sv4/212_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-213",
@@ -12150,7 +12972,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/213.png",
       "large": "https://images.pokemontcg.io/sv4/213_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-214",
@@ -12209,7 +13034,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/214.png",
       "large": "https://images.pokemontcg.io/sv4/214_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-215",
@@ -12270,7 +13098,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/215.png",
       "large": "https://images.pokemontcg.io/sv4/215_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-216",
@@ -12343,7 +13174,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/216.png",
       "large": "https://images.pokemontcg.io/sv4/216_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-217",
@@ -12407,7 +13241,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/217.png",
       "large": "https://images.pokemontcg.io/sv4/217_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-218",
@@ -12470,7 +13307,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/218.png",
       "large": "https://images.pokemontcg.io/sv4/218_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-219",
@@ -12532,7 +13372,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/219.png",
       "large": "https://images.pokemontcg.io/sv4/219_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-220",
@@ -12599,7 +13442,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/220.png",
       "large": "https://images.pokemontcg.io/sv4/220_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-221",
@@ -12667,7 +13513,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/221.png",
       "large": "https://images.pokemontcg.io/sv4/221_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-222",
@@ -12732,7 +13581,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/222.png",
       "large": "https://images.pokemontcg.io/sv4/222_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-223",
@@ -12803,7 +13655,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/223.png",
       "large": "https://images.pokemontcg.io/sv4/223_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-224",
@@ -12872,7 +13727,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/224.png",
       "large": "https://images.pokemontcg.io/sv4/224_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-225",
@@ -12936,7 +13794,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/225.png",
       "large": "https://images.pokemontcg.io/sv4/225_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-226",
@@ -13004,7 +13865,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/226.png",
       "large": "https://images.pokemontcg.io/sv4/226_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-227",
@@ -13073,7 +13937,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/227.png",
       "large": "https://images.pokemontcg.io/sv4/227_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-228",
@@ -13137,7 +14004,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/228.png",
       "large": "https://images.pokemontcg.io/sv4/228_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-229",
@@ -13205,7 +14075,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/229.png",
       "large": "https://images.pokemontcg.io/sv4/229_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-230",
@@ -13277,7 +14150,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/230.png",
       "large": "https://images.pokemontcg.io/sv4/230_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-231",
@@ -13345,7 +14221,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/231.png",
       "large": "https://images.pokemontcg.io/sv4/231_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-232",
@@ -13401,7 +14280,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/232.png",
       "large": "https://images.pokemontcg.io/sv4/232_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-233",
@@ -13459,7 +14341,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/233.png",
       "large": "https://images.pokemontcg.io/sv4/233_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-234",
@@ -13529,7 +14414,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/234.png",
       "large": "https://images.pokemontcg.io/sv4/234_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-235",
@@ -13554,7 +14442,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/235.png",
       "large": "https://images.pokemontcg.io/sv4/235_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-236",
@@ -13579,7 +14470,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/236.png",
       "large": "https://images.pokemontcg.io/sv4/236_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-237",
@@ -13604,7 +14498,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/237.png",
       "large": "https://images.pokemontcg.io/sv4/237_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-238",
@@ -13629,7 +14526,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/238.png",
       "large": "https://images.pokemontcg.io/sv4/238_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-239",
@@ -13655,7 +14555,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/239.png",
       "large": "https://images.pokemontcg.io/sv4/239_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-240",
@@ -13681,7 +14584,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/240.png",
       "large": "https://images.pokemontcg.io/sv4/240_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-241",
@@ -13706,7 +14612,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/241.png",
       "large": "https://images.pokemontcg.io/sv4/241_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-242",
@@ -13731,7 +14640,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/242.png",
       "large": "https://images.pokemontcg.io/sv4/242_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-243",
@@ -13756,7 +14668,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/243.png",
       "large": "https://images.pokemontcg.io/sv4/243_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-244",
@@ -13781,7 +14696,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/244.png",
       "large": "https://images.pokemontcg.io/sv4/244_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-245",
@@ -13843,7 +14761,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/245.png",
       "large": "https://images.pokemontcg.io/sv4/245_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-246",
@@ -13911,7 +14832,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/246.png",
       "large": "https://images.pokemontcg.io/sv4/246_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-247",
@@ -13976,7 +14900,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/247.png",
       "large": "https://images.pokemontcg.io/sv4/247_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-248",
@@ -14047,7 +14974,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/248.png",
       "large": "https://images.pokemontcg.io/sv4/248_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-249",
@@ -14111,7 +15041,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/249.png",
       "large": "https://images.pokemontcg.io/sv4/249_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-250",
@@ -14175,7 +15108,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/250.png",
       "large": "https://images.pokemontcg.io/sv4/250_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-251",
@@ -14243,7 +15179,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/251.png",
       "large": "https://images.pokemontcg.io/sv4/251_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-252",
@@ -14311,7 +15250,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/252.png",
       "large": "https://images.pokemontcg.io/sv4/252_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-253",
@@ -14367,7 +15309,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/253.png",
       "large": "https://images.pokemontcg.io/sv4/253_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-254",
@@ -14392,7 +15337,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/254.png",
       "large": "https://images.pokemontcg.io/sv4/254_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-255",
@@ -14417,7 +15365,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/255.png",
       "large": "https://images.pokemontcg.io/sv4/255_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-256",
@@ -14443,7 +15394,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/256.png",
       "large": "https://images.pokemontcg.io/sv4/256_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-257",
@@ -14469,7 +15423,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/257.png",
       "large": "https://images.pokemontcg.io/sv4/257_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-258",
@@ -14494,7 +15451,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/258.png",
       "large": "https://images.pokemontcg.io/sv4/258_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-259",
@@ -14519,7 +15479,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/259.png",
       "large": "https://images.pokemontcg.io/sv4/259_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-260",
@@ -14581,7 +15544,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/260.png",
       "large": "https://images.pokemontcg.io/sv4/260_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-261",
@@ -14645,7 +15611,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/261.png",
       "large": "https://images.pokemontcg.io/sv4/261_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-262",
@@ -14713,7 +15682,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/262.png",
       "large": "https://images.pokemontcg.io/sv4/262_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-263",
@@ -14738,7 +15710,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/263.png",
       "large": "https://images.pokemontcg.io/sv4/263_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-264",
@@ -14763,7 +15738,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/264.png",
       "large": "https://images.pokemontcg.io/sv4/264_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-265",
@@ -14788,7 +15766,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/265.png",
       "large": "https://images.pokemontcg.io/sv4/265_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4-266",
@@ -14811,6 +15792,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4/266.png",
       "large": "https://images.pokemontcg.io/sv4/266_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv4pt5.json
+++ b/cards/en/sv4pt5.json
@@ -52,7 +52,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/1.png",
       "large": "https://images.pokemontcg.io/sv4pt5/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-2",
@@ -118,7 +122,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/2.png",
       "large": "https://images.pokemontcg.io/sv4pt5/2_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-3",
@@ -180,7 +187,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/3.png",
       "large": "https://images.pokemontcg.io/sv4pt5/3_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-4",
@@ -230,7 +241,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/4.png",
       "large": "https://images.pokemontcg.io/sv4pt5/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-5",
@@ -293,7 +308,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/5.png",
       "large": "https://images.pokemontcg.io/sv4pt5/5_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-6",
@@ -356,7 +374,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/6.png",
       "large": "https://images.pokemontcg.io/sv4pt5/6_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-7",
@@ -419,7 +440,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/7.png",
       "large": "https://images.pokemontcg.io/sv4pt5/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-8",
@@ -482,7 +507,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/8.png",
       "large": "https://images.pokemontcg.io/sv4pt5/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-9",
@@ -546,7 +575,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/9.png",
       "large": "https://images.pokemontcg.io/sv4pt5/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-10",
@@ -610,7 +643,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/10.png",
       "large": "https://images.pokemontcg.io/sv4pt5/10_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-11",
@@ -676,7 +713,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/11.png",
       "large": "https://images.pokemontcg.io/sv4pt5/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-12",
@@ -740,7 +781,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/12.png",
       "large": "https://images.pokemontcg.io/sv4pt5/12_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-13",
@@ -791,7 +836,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/13.png",
       "large": "https://images.pokemontcg.io/sv4pt5/13_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-14",
@@ -843,7 +892,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/14.png",
       "large": "https://images.pokemontcg.io/sv4pt5/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-15",
@@ -904,7 +957,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/15.png",
       "large": "https://images.pokemontcg.io/sv4pt5/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-16",
@@ -964,7 +1021,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/16.png",
       "large": "https://images.pokemontcg.io/sv4pt5/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-17",
@@ -1025,7 +1086,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/17.png",
       "large": "https://images.pokemontcg.io/sv4pt5/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-18",
@@ -1088,7 +1153,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/18.png",
       "large": "https://images.pokemontcg.io/sv4pt5/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-19",
@@ -1148,7 +1217,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/19.png",
       "large": "https://images.pokemontcg.io/sv4pt5/19_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-20",
@@ -1211,7 +1284,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/20.png",
       "large": "https://images.pokemontcg.io/sv4pt5/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-21",
@@ -1275,7 +1352,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/21.png",
       "large": "https://images.pokemontcg.io/sv4pt5/21_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-22",
@@ -1339,7 +1420,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/22.png",
       "large": "https://images.pokemontcg.io/sv4pt5/22_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-23",
@@ -1409,7 +1494,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/23.png",
       "large": "https://images.pokemontcg.io/sv4pt5/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-24",
@@ -1479,7 +1568,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/24.png",
       "large": "https://images.pokemontcg.io/sv4pt5/24_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-25",
@@ -1538,7 +1631,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/25.png",
       "large": "https://images.pokemontcg.io/sv4pt5/25_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-26",
@@ -1604,7 +1701,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/26.png",
       "large": "https://images.pokemontcg.io/sv4pt5/26_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-27",
@@ -1664,7 +1765,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/27.png",
       "large": "https://images.pokemontcg.io/sv4pt5/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-28",
@@ -1737,7 +1842,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/28.png",
       "large": "https://images.pokemontcg.io/sv4pt5/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-29",
@@ -1807,7 +1916,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/29.png",
       "large": "https://images.pokemontcg.io/sv4pt5/29_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-30",
@@ -1875,7 +1987,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/30.png",
       "large": "https://images.pokemontcg.io/sv4pt5/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-31",
@@ -1927,7 +2043,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/31.png",
       "large": "https://images.pokemontcg.io/sv4pt5/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-32",
@@ -1986,7 +2106,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/32.png",
       "large": "https://images.pokemontcg.io/sv4pt5/32_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-33",
@@ -2043,7 +2167,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/33.png",
       "large": "https://images.pokemontcg.io/sv4pt5/33_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-34",
@@ -2096,7 +2224,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/34.png",
       "large": "https://images.pokemontcg.io/sv4pt5/34_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-35",
@@ -2143,7 +2275,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/35.png",
       "large": "https://images.pokemontcg.io/sv4pt5/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-36",
@@ -2203,7 +2339,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/36.png",
       "large": "https://images.pokemontcg.io/sv4pt5/36_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-37",
@@ -2261,7 +2401,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/37.png",
       "large": "https://images.pokemontcg.io/sv4pt5/37_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-38",
@@ -2312,7 +2456,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/38.png",
       "large": "https://images.pokemontcg.io/sv4pt5/38_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-39",
@@ -2372,7 +2520,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/39.png",
       "large": "https://images.pokemontcg.io/sv4pt5/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-40",
@@ -2442,7 +2594,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/40.png",
       "large": "https://images.pokemontcg.io/sv4pt5/40_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Pokémon Day"
+    ]
   },
   {
     "id": "sv4pt5-41",
@@ -2499,7 +2656,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/41.png",
       "large": "https://images.pokemontcg.io/sv4pt5/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-42",
@@ -2556,7 +2717,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/42.png",
       "large": "https://images.pokemontcg.io/sv4pt5/42_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-43",
@@ -2616,7 +2781,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/43.png",
       "large": "https://images.pokemontcg.io/sv4pt5/43_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-44",
@@ -2681,7 +2850,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/44.png",
       "large": "https://images.pokemontcg.io/sv4pt5/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-45",
@@ -2734,7 +2907,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/45.png",
       "large": "https://images.pokemontcg.io/sv4pt5/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-46",
@@ -2785,7 +2962,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/46.png",
       "large": "https://images.pokemontcg.io/sv4pt5/46_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-47",
@@ -2847,7 +3028,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/47.png",
       "large": "https://images.pokemontcg.io/sv4pt5/47_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-48",
@@ -2913,7 +3098,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/48.png",
       "large": "https://images.pokemontcg.io/sv4pt5/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-49",
@@ -2978,7 +3167,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/49.png",
       "large": "https://images.pokemontcg.io/sv4pt5/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-50",
@@ -3042,7 +3235,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/50.png",
       "large": "https://images.pokemontcg.io/sv4pt5/50_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-51",
@@ -3096,7 +3293,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/51.png",
       "large": "https://images.pokemontcg.io/sv4pt5/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-52",
@@ -3159,7 +3360,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/52.png",
       "large": "https://images.pokemontcg.io/sv4pt5/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-53",
@@ -3226,7 +3431,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/53.png",
       "large": "https://images.pokemontcg.io/sv4pt5/53_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-54",
@@ -3291,7 +3499,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/54.png",
       "large": "https://images.pokemontcg.io/sv4pt5/54_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-55",
@@ -3354,7 +3565,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/55.png",
       "large": "https://images.pokemontcg.io/sv4pt5/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-56",
@@ -3409,7 +3624,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/56.png",
       "large": "https://images.pokemontcg.io/sv4pt5/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-57",
@@ -3468,7 +3687,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/57.png",
       "large": "https://images.pokemontcg.io/sv4pt5/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-58",
@@ -3531,7 +3754,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/58.png",
       "large": "https://images.pokemontcg.io/sv4pt5/58_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-59",
@@ -3596,7 +3823,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/59.png",
       "large": "https://images.pokemontcg.io/sv4pt5/59_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-60",
@@ -3660,7 +3890,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/60.png",
       "large": "https://images.pokemontcg.io/sv4pt5/60_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-61",
@@ -3723,7 +3957,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/61.png",
       "large": "https://images.pokemontcg.io/sv4pt5/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-62",
@@ -3773,7 +4011,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/62.png",
       "large": "https://images.pokemontcg.io/sv4pt5/62_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-63",
@@ -3835,7 +4077,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/63.png",
       "large": "https://images.pokemontcg.io/sv4pt5/63_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-64",
@@ -3901,7 +4147,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/64.png",
       "large": "https://images.pokemontcg.io/sv4pt5/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-65",
@@ -3969,7 +4219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/65.png",
       "large": "https://images.pokemontcg.io/sv4pt5/65_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-66",
@@ -4033,7 +4287,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/66.png",
       "large": "https://images.pokemontcg.io/sv4pt5/66_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-67",
@@ -4102,7 +4359,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/67.png",
       "large": "https://images.pokemontcg.io/sv4pt5/67_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-68",
@@ -4150,7 +4411,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/68.png",
       "large": "https://images.pokemontcg.io/sv4pt5/68_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-69",
@@ -4205,7 +4470,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/69.png",
       "large": "https://images.pokemontcg.io/sv4pt5/69_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-70",
@@ -4251,7 +4519,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/70.png",
       "large": "https://images.pokemontcg.io/sv4pt5/70_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-71",
@@ -4303,7 +4575,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/71.png",
       "large": "https://images.pokemontcg.io/sv4pt5/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-72",
@@ -4367,7 +4643,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/72.png",
       "large": "https://images.pokemontcg.io/sv4pt5/72_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-73",
@@ -4428,7 +4708,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/73.png",
       "large": "https://images.pokemontcg.io/sv4pt5/73_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-74",
@@ -4489,7 +4773,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/74.png",
       "large": "https://images.pokemontcg.io/sv4pt5/74_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-75",
@@ -4555,7 +4843,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/75.png",
       "large": "https://images.pokemontcg.io/sv4pt5/75_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-76",
@@ -4580,7 +4871,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/76.png",
       "large": "https://images.pokemontcg.io/sv4pt5/76_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-77",
@@ -4606,7 +4901,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/77.png",
       "large": "https://images.pokemontcg.io/sv4pt5/77_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-78",
@@ -4631,7 +4930,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/78.png",
       "large": "https://images.pokemontcg.io/sv4pt5/78_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-79",
@@ -4656,7 +4959,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/79.png",
       "large": "https://images.pokemontcg.io/sv4pt5/79_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-80",
@@ -4681,7 +4988,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/80.png",
       "large": "https://images.pokemontcg.io/sv4pt5/80_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-81",
@@ -4706,7 +5017,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/81.png",
       "large": "https://images.pokemontcg.io/sv4pt5/81_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-82",
@@ -4731,7 +5046,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/82.png",
       "large": "https://images.pokemontcg.io/sv4pt5/82_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-83",
@@ -4756,7 +5075,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/83.png",
       "large": "https://images.pokemontcg.io/sv4pt5/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-84",
@@ -4781,7 +5104,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/84.png",
       "large": "https://images.pokemontcg.io/sv4pt5/84_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-85",
@@ -4806,7 +5133,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/85.png",
       "large": "https://images.pokemontcg.io/sv4pt5/85_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-86",
@@ -4831,7 +5162,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/86.png",
       "large": "https://images.pokemontcg.io/sv4pt5/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-87",
@@ -4856,7 +5191,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/87.png",
       "large": "https://images.pokemontcg.io/sv4pt5/87_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-88",
@@ -4881,7 +5220,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/88.png",
       "large": "https://images.pokemontcg.io/sv4pt5/88_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-89",
@@ -4906,7 +5249,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/89.png",
       "large": "https://images.pokemontcg.io/sv4pt5/89_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-90",
@@ -4944,7 +5291,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/90.png",
       "large": "https://images.pokemontcg.io/sv4pt5/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-91",
@@ -4970,7 +5321,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/91.png",
       "large": "https://images.pokemontcg.io/sv4pt5/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv4pt5-92",
@@ -5024,7 +5379,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/92.png",
       "large": "https://images.pokemontcg.io/sv4pt5/92_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-93",
@@ -5087,7 +5445,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/93.png",
       "large": "https://images.pokemontcg.io/sv4pt5/93_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-94",
@@ -5148,7 +5509,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/94.png",
       "large": "https://images.pokemontcg.io/sv4pt5/94_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-95",
@@ -5211,7 +5575,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/95.png",
       "large": "https://images.pokemontcg.io/sv4pt5/95_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-96",
@@ -5264,7 +5631,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/96.png",
       "large": "https://images.pokemontcg.io/sv4pt5/96_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-97",
@@ -5325,7 +5695,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/97.png",
       "large": "https://images.pokemontcg.io/sv4pt5/97_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-98",
@@ -5383,7 +5756,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/98.png",
       "large": "https://images.pokemontcg.io/sv4pt5/98_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-99",
@@ -5438,7 +5814,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/99.png",
       "large": "https://images.pokemontcg.io/sv4pt5/99_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-100",
@@ -5494,7 +5873,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/100.png",
       "large": "https://images.pokemontcg.io/sv4pt5/100_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-101",
@@ -5556,7 +5938,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/101.png",
       "large": "https://images.pokemontcg.io/sv4pt5/101_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-102",
@@ -5616,7 +6001,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/102.png",
       "large": "https://images.pokemontcg.io/sv4pt5/102_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-103",
@@ -5677,7 +6065,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/103.png",
       "large": "https://images.pokemontcg.io/sv4pt5/103_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-104",
@@ -5738,7 +6129,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/104.png",
       "large": "https://images.pokemontcg.io/sv4pt5/104_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-105",
@@ -5788,7 +6182,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/105.png",
       "large": "https://images.pokemontcg.io/sv4pt5/105_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-106",
@@ -5849,7 +6246,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/106.png",
       "large": "https://images.pokemontcg.io/sv4pt5/106_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-107",
@@ -5910,7 +6310,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/107.png",
       "large": "https://images.pokemontcg.io/sv4pt5/107_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-108",
@@ -5961,7 +6364,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/108.png",
       "large": "https://images.pokemontcg.io/sv4pt5/108_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-109",
@@ -6024,7 +6430,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/109.png",
       "large": "https://images.pokemontcg.io/sv4pt5/109_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-110",
@@ -6087,7 +6496,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/110.png",
       "large": "https://images.pokemontcg.io/sv4pt5/110_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-111",
@@ -6150,7 +6562,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/111.png",
       "large": "https://images.pokemontcg.io/sv4pt5/111_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-112",
@@ -6210,7 +6625,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/112.png",
       "large": "https://images.pokemontcg.io/sv4pt5/112_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-113",
@@ -6268,7 +6686,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/113.png",
       "large": "https://images.pokemontcg.io/sv4pt5/113_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-114",
@@ -6320,7 +6741,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/114.png",
       "large": "https://images.pokemontcg.io/sv4pt5/114_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-115",
@@ -6381,7 +6805,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/115.png",
       "large": "https://images.pokemontcg.io/sv4pt5/115_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-116",
@@ -6446,7 +6873,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/116.png",
       "large": "https://images.pokemontcg.io/sv4pt5/116_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-117",
@@ -6507,7 +6937,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/117.png",
       "large": "https://images.pokemontcg.io/sv4pt5/117_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-118",
@@ -6561,7 +6994,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/118.png",
       "large": "https://images.pokemontcg.io/sv4pt5/118_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-119",
@@ -6620,7 +7056,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/119.png",
       "large": "https://images.pokemontcg.io/sv4pt5/119_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-120",
@@ -6683,7 +7122,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/120.png",
       "large": "https://images.pokemontcg.io/sv4pt5/120_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-121",
@@ -6733,7 +7175,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/121.png",
       "large": "https://images.pokemontcg.io/sv4pt5/121_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-122",
@@ -6796,7 +7241,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/122.png",
       "large": "https://images.pokemontcg.io/sv4pt5/122_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-123",
@@ -6856,7 +7304,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/123.png",
       "large": "https://images.pokemontcg.io/sv4pt5/123_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-124",
@@ -6918,7 +7369,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/124.png",
       "large": "https://images.pokemontcg.io/sv4pt5/124_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-125",
@@ -6981,7 +7435,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/125.png",
       "large": "https://images.pokemontcg.io/sv4pt5/125_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-126",
@@ -7047,7 +7504,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/126.png",
       "large": "https://images.pokemontcg.io/sv4pt5/126_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-127",
@@ -7106,7 +7566,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/127.png",
       "large": "https://images.pokemontcg.io/sv4pt5/127_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-128",
@@ -7167,7 +7630,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/128.png",
       "large": "https://images.pokemontcg.io/sv4pt5/128_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-129",
@@ -7231,7 +7697,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/129.png",
       "large": "https://images.pokemontcg.io/sv4pt5/129_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-130",
@@ -7292,7 +7761,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/130.png",
       "large": "https://images.pokemontcg.io/sv4pt5/130_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-131",
@@ -7355,7 +7827,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/131.png",
       "large": "https://images.pokemontcg.io/sv4pt5/131_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-132",
@@ -7415,7 +7890,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/132.png",
       "large": "https://images.pokemontcg.io/sv4pt5/132_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-133",
@@ -7468,7 +7946,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/133.png",
       "large": "https://images.pokemontcg.io/sv4pt5/133_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-134",
@@ -7529,7 +8010,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/134.png",
       "large": "https://images.pokemontcg.io/sv4pt5/134_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-135",
@@ -7582,7 +8066,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/135.png",
       "large": "https://images.pokemontcg.io/sv4pt5/135_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-136",
@@ -7647,7 +8134,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/136.png",
       "large": "https://images.pokemontcg.io/sv4pt5/136_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-137",
@@ -7707,7 +8197,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/137.png",
       "large": "https://images.pokemontcg.io/sv4pt5/137_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-138",
@@ -7765,7 +8258,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/138.png",
       "large": "https://images.pokemontcg.io/sv4pt5/138_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-139",
@@ -7824,7 +8320,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/139.png",
       "large": "https://images.pokemontcg.io/sv4pt5/139_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-140",
@@ -7877,7 +8376,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/140.png",
       "large": "https://images.pokemontcg.io/sv4pt5/140_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-141",
@@ -7939,7 +8441,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/141.png",
       "large": "https://images.pokemontcg.io/sv4pt5/141_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-142",
@@ -7999,7 +8504,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/142.png",
       "large": "https://images.pokemontcg.io/sv4pt5/142_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-143",
@@ -8061,7 +8569,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/143.png",
       "large": "https://images.pokemontcg.io/sv4pt5/143_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-144",
@@ -8117,7 +8628,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/144.png",
       "large": "https://images.pokemontcg.io/sv4pt5/144_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-145",
@@ -8183,7 +8697,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/145.png",
       "large": "https://images.pokemontcg.io/sv4pt5/145_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-146",
@@ -8247,7 +8764,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/146.png",
       "large": "https://images.pokemontcg.io/sv4pt5/146_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-147",
@@ -8308,7 +8828,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/147.png",
       "large": "https://images.pokemontcg.io/sv4pt5/147_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-148",
@@ -8367,7 +8890,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/148.png",
       "large": "https://images.pokemontcg.io/sv4pt5/148_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-149",
@@ -8427,7 +8953,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/149.png",
       "large": "https://images.pokemontcg.io/sv4pt5/149_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-150",
@@ -8476,7 +9005,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/150.png",
       "large": "https://images.pokemontcg.io/sv4pt5/150_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-151",
@@ -8535,7 +9067,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/151.png",
       "large": "https://images.pokemontcg.io/sv4pt5/151_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-152",
@@ -8601,7 +9136,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/152.png",
       "large": "https://images.pokemontcg.io/sv4pt5/152_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-153",
@@ -8661,7 +9199,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/153.png",
       "large": "https://images.pokemontcg.io/sv4pt5/153_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-154",
@@ -8734,7 +9275,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/154.png",
       "large": "https://images.pokemontcg.io/sv4pt5/154_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-155",
@@ -8804,7 +9348,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/155.png",
       "large": "https://images.pokemontcg.io/sv4pt5/155_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-156",
@@ -8873,7 +9420,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/156.png",
       "large": "https://images.pokemontcg.io/sv4pt5/156_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-157",
@@ -8925,7 +9475,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/157.png",
       "large": "https://images.pokemontcg.io/sv4pt5/157_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-158",
@@ -8988,7 +9541,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/158.png",
       "large": "https://images.pokemontcg.io/sv4pt5/158_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-159",
@@ -9045,7 +9601,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/159.png",
       "large": "https://images.pokemontcg.io/sv4pt5/159_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-160",
@@ -9103,7 +9662,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/160.png",
       "large": "https://images.pokemontcg.io/sv4pt5/160_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-161",
@@ -9163,7 +9725,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/161.png",
       "large": "https://images.pokemontcg.io/sv4pt5/161_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-162",
@@ -9233,7 +9798,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/162.png",
       "large": "https://images.pokemontcg.io/sv4pt5/162_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-163",
@@ -9300,7 +9868,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/163.png",
       "large": "https://images.pokemontcg.io/sv4pt5/163_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-164",
@@ -9357,7 +9928,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/164.png",
       "large": "https://images.pokemontcg.io/sv4pt5/164_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-165",
@@ -9418,7 +9992,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/165.png",
       "large": "https://images.pokemontcg.io/sv4pt5/165_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-166",
@@ -9482,7 +10059,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/166.png",
       "large": "https://images.pokemontcg.io/sv4pt5/166_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-167",
@@ -9542,7 +10122,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/167.png",
       "large": "https://images.pokemontcg.io/sv4pt5/167_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-168",
@@ -9602,7 +10185,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/168.png",
       "large": "https://images.pokemontcg.io/sv4pt5/168_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-169",
@@ -9655,7 +10241,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/169.png",
       "large": "https://images.pokemontcg.io/sv4pt5/169_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-170",
@@ -9706,7 +10295,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/170.png",
       "large": "https://images.pokemontcg.io/sv4pt5/170_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-171",
@@ -9768,7 +10360,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/171.png",
       "large": "https://images.pokemontcg.io/sv4pt5/171_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-172",
@@ -9831,7 +10426,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/172.png",
       "large": "https://images.pokemontcg.io/sv4pt5/172_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-173",
@@ -9894,7 +10492,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/173.png",
       "large": "https://images.pokemontcg.io/sv4pt5/173_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-174",
@@ -9957,7 +10558,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/174.png",
       "large": "https://images.pokemontcg.io/sv4pt5/174_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-175",
@@ -10016,7 +10620,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/175.png",
       "large": "https://images.pokemontcg.io/sv4pt5/175_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-176",
@@ -10078,7 +10685,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/176.png",
       "large": "https://images.pokemontcg.io/sv4pt5/176_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-177",
@@ -10132,7 +10742,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/177.png",
       "large": "https://images.pokemontcg.io/sv4pt5/177_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-178",
@@ -10193,7 +10806,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/178.png",
       "large": "https://images.pokemontcg.io/sv4pt5/178_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-179",
@@ -10243,7 +10859,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/179.png",
       "large": "https://images.pokemontcg.io/sv4pt5/179_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-180",
@@ -10306,7 +10925,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/180.png",
       "large": "https://images.pokemontcg.io/sv4pt5/180_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-181",
@@ -10374,7 +10996,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/181.png",
       "large": "https://images.pokemontcg.io/sv4pt5/181_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-182",
@@ -10427,7 +11052,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/182.png",
       "large": "https://images.pokemontcg.io/sv4pt5/182_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-183",
@@ -10486,7 +11114,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/183.png",
       "large": "https://images.pokemontcg.io/sv4pt5/183_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-184",
@@ -10545,7 +11176,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/184.png",
       "large": "https://images.pokemontcg.io/sv4pt5/184_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-185",
@@ -10608,7 +11242,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/185.png",
       "large": "https://images.pokemontcg.io/sv4pt5/185_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-186",
@@ -10669,7 +11306,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/186.png",
       "large": "https://images.pokemontcg.io/sv4pt5/186_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-187",
@@ -10731,7 +11371,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/187.png",
       "large": "https://images.pokemontcg.io/sv4pt5/187_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-188",
@@ -10793,7 +11436,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/188.png",
       "large": "https://images.pokemontcg.io/sv4pt5/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-189",
@@ -10852,7 +11498,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/189.png",
       "large": "https://images.pokemontcg.io/sv4pt5/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-190",
@@ -10912,7 +11561,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/190.png",
       "large": "https://images.pokemontcg.io/sv4pt5/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-191",
@@ -10980,7 +11632,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/191.png",
       "large": "https://images.pokemontcg.io/sv4pt5/191_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-192",
@@ -11046,7 +11701,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/192.png",
       "large": "https://images.pokemontcg.io/sv4pt5/192_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-193",
@@ -11114,7 +11772,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/193.png",
       "large": "https://images.pokemontcg.io/sv4pt5/193_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-194",
@@ -11162,7 +11823,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/194.png",
       "large": "https://images.pokemontcg.io/sv4pt5/194_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-195",
@@ -11208,7 +11872,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/195.png",
       "large": "https://images.pokemontcg.io/sv4pt5/195_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-196",
@@ -11277,7 +11944,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/196.png",
       "large": "https://images.pokemontcg.io/sv4pt5/196_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-197",
@@ -11333,7 +12003,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/197.png",
       "large": "https://images.pokemontcg.io/sv4pt5/197_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-198",
@@ -11396,7 +12069,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/198.png",
       "large": "https://images.pokemontcg.io/sv4pt5/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-199",
@@ -11455,7 +12131,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/199.png",
       "large": "https://images.pokemontcg.io/sv4pt5/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-200",
@@ -11519,7 +12198,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/200.png",
       "large": "https://images.pokemontcg.io/sv4pt5/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-201",
@@ -11576,7 +12258,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/201.png",
       "large": "https://images.pokemontcg.io/sv4pt5/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-202",
@@ -11638,7 +12323,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/202.png",
       "large": "https://images.pokemontcg.io/sv4pt5/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-203",
@@ -11698,7 +12386,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/203.png",
       "large": "https://images.pokemontcg.io/sv4pt5/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-204",
@@ -11765,7 +12456,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/204.png",
       "large": "https://images.pokemontcg.io/sv4pt5/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-205",
@@ -11826,7 +12520,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/205.png",
       "large": "https://images.pokemontcg.io/sv4pt5/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-206",
@@ -11890,7 +12587,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/206.png",
       "large": "https://images.pokemontcg.io/sv4pt5/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-207",
@@ -11942,7 +12642,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/207.png",
       "large": "https://images.pokemontcg.io/sv4pt5/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-208",
@@ -12006,7 +12709,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/208.png",
       "large": "https://images.pokemontcg.io/sv4pt5/208_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-209",
@@ -12067,7 +12773,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/209.png",
       "large": "https://images.pokemontcg.io/sv4pt5/209_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-210",
@@ -12128,7 +12837,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/210.png",
       "large": "https://images.pokemontcg.io/sv4pt5/210_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-211",
@@ -12192,7 +12904,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/211.png",
       "large": "https://images.pokemontcg.io/sv4pt5/211_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-212",
@@ -12258,7 +12973,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/212.png",
       "large": "https://images.pokemontcg.io/sv4pt5/212_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-213",
@@ -12321,7 +13039,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/213.png",
       "large": "https://images.pokemontcg.io/sv4pt5/213_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-214",
@@ -12384,7 +13105,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/214.png",
       "large": "https://images.pokemontcg.io/sv4pt5/214_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-215",
@@ -12455,7 +13179,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/215.png",
       "large": "https://images.pokemontcg.io/sv4pt5/215_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-216",
@@ -12519,7 +13246,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/216.png",
       "large": "https://images.pokemontcg.io/sv4pt5/216_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-217",
@@ -12589,7 +13319,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/217.png",
       "large": "https://images.pokemontcg.io/sv4pt5/217_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-218",
@@ -12653,7 +13386,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/218.png",
       "large": "https://images.pokemontcg.io/sv4pt5/218_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-219",
@@ -12718,7 +13454,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/219.png",
       "large": "https://images.pokemontcg.io/sv4pt5/219_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-220",
@@ -12773,7 +13512,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/220.png",
       "large": "https://images.pokemontcg.io/sv4pt5/220_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-221",
@@ -12837,7 +13579,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/221.png",
       "large": "https://images.pokemontcg.io/sv4pt5/221_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-222",
@@ -12902,7 +13647,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/222.png",
       "large": "https://images.pokemontcg.io/sv4pt5/222_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-223",
@@ -12968,7 +13716,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/223.png",
       "large": "https://images.pokemontcg.io/sv4pt5/223_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-224",
@@ -13031,7 +13782,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/224.png",
       "large": "https://images.pokemontcg.io/sv4pt5/224_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-225",
@@ -13093,7 +13847,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/225.png",
       "large": "https://images.pokemontcg.io/sv4pt5/225_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-226",
@@ -13153,7 +13910,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/226.png",
       "large": "https://images.pokemontcg.io/sv4pt5/226_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-227",
@@ -13178,7 +13938,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/227.png",
       "large": "https://images.pokemontcg.io/sv4pt5/227_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-228",
@@ -13203,7 +13966,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/228.png",
       "large": "https://images.pokemontcg.io/sv4pt5/228_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-229",
@@ -13228,7 +13994,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/229.png",
       "large": "https://images.pokemontcg.io/sv4pt5/229_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-230",
@@ -13253,7 +14022,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/230.png",
       "large": "https://images.pokemontcg.io/sv4pt5/230_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-231",
@@ -13278,7 +14050,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/231.png",
       "large": "https://images.pokemontcg.io/sv4pt5/231_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-232",
@@ -13342,7 +14117,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/232.png",
       "large": "https://images.pokemontcg.io/sv4pt5/232_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-233",
@@ -13412,7 +14190,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/233.png",
       "large": "https://images.pokemontcg.io/sv4pt5/233_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-234",
@@ -13477,7 +14258,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/234.png",
       "large": "https://images.pokemontcg.io/sv4pt5/234_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-235",
@@ -13502,7 +14286,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/235.png",
       "large": "https://images.pokemontcg.io/sv4pt5/235_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-236",
@@ -13527,7 +14314,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/236.png",
       "large": "https://images.pokemontcg.io/sv4pt5/236_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-237",
@@ -13552,7 +14342,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/237.png",
       "large": "https://images.pokemontcg.io/sv4pt5/237_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-238",
@@ -13577,7 +14370,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/238.png",
       "large": "https://images.pokemontcg.io/sv4pt5/238_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-239",
@@ -13602,7 +14398,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/239.png",
       "large": "https://images.pokemontcg.io/sv4pt5/239_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-240",
@@ -13672,7 +14471,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/240.png",
       "large": "https://images.pokemontcg.io/sv4pt5/240_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-241",
@@ -13735,7 +14537,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/241.png",
       "large": "https://images.pokemontcg.io/sv4pt5/241_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-242",
@@ -13797,7 +14602,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/242.png",
       "large": "https://images.pokemontcg.io/sv4pt5/242_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-243",
@@ -13859,7 +14667,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/243.png",
       "large": "https://images.pokemontcg.io/sv4pt5/243_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-244",
@@ -13924,7 +14735,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/244.png",
       "large": "https://images.pokemontcg.io/sv4pt5/244_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv4pt5-245",
@@ -13987,6 +14801,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv4pt5/245.png",
       "large": "https://images.pokemontcg.io/sv4pt5/245_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv5.json
+++ b/cards/en/sv5.json
@@ -60,7 +60,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/1.png",
       "large": "https://images.pokemontcg.io/sv5/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-2",
@@ -116,7 +120,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/2.png",
       "large": "https://images.pokemontcg.io/sv5/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-3",
@@ -179,7 +187,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/3.png",
       "large": "https://images.pokemontcg.io/sv5/3_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-4",
@@ -243,7 +255,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/4.png",
       "large": "https://images.pokemontcg.io/sv5/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-5",
@@ -305,7 +321,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/5.png",
       "large": "https://images.pokemontcg.io/sv5/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-6",
@@ -368,7 +388,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/6.png",
       "large": "https://images.pokemontcg.io/sv5/6_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-7",
@@ -429,7 +453,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/7.png",
       "large": "https://images.pokemontcg.io/sv5/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-8",
@@ -489,7 +517,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/8.png",
       "large": "https://images.pokemontcg.io/sv5/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-9",
@@ -549,7 +581,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/9.png",
       "large": "https://images.pokemontcg.io/sv5/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-10",
@@ -613,7 +649,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/10.png",
       "large": "https://images.pokemontcg.io/sv5/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-11",
@@ -681,7 +721,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/11.png",
       "large": "https://images.pokemontcg.io/sv5/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-12",
@@ -749,7 +793,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/12.png",
       "large": "https://images.pokemontcg.io/sv5/12_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-13",
@@ -805,7 +852,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/13.png",
       "large": "https://images.pokemontcg.io/sv5/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-14",
@@ -858,7 +909,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/14.png",
       "large": "https://images.pokemontcg.io/sv5/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-15",
@@ -916,7 +971,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/15.png",
       "large": "https://images.pokemontcg.io/sv5/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-16",
@@ -980,7 +1039,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/16.png",
       "large": "https://images.pokemontcg.io/sv5/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-17",
@@ -1041,7 +1104,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/17.png",
       "large": "https://images.pokemontcg.io/sv5/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-18",
@@ -1104,7 +1171,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/18.png",
       "large": "https://images.pokemontcg.io/sv5/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-19",
@@ -1168,7 +1239,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/19.png",
       "large": "https://images.pokemontcg.io/sv5/19_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-20",
@@ -1219,7 +1294,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/20.png",
       "large": "https://images.pokemontcg.io/sv5/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-21",
@@ -1281,7 +1360,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/21.png",
       "large": "https://images.pokemontcg.io/sv5/21_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-22",
@@ -1346,7 +1429,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/22.png",
       "large": "https://images.pokemontcg.io/sv5/22_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-23",
@@ -1396,7 +1482,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/23.png",
       "large": "https://images.pokemontcg.io/sv5/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-24",
@@ -1454,7 +1544,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/24.png",
       "large": "https://images.pokemontcg.io/sv5/24_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-25",
@@ -1517,7 +1611,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/25.png",
       "large": "https://images.pokemontcg.io/sv5/25_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-26",
@@ -1580,7 +1677,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/26.png",
       "large": "https://images.pokemontcg.io/sv5/26_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-27",
@@ -1637,7 +1738,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/27.png",
       "large": "https://images.pokemontcg.io/sv5/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-28",
@@ -1691,7 +1796,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/28.png",
       "large": "https://images.pokemontcg.io/sv5/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-29",
@@ -1754,7 +1863,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/29.png",
       "large": "https://images.pokemontcg.io/sv5/29_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-30",
@@ -1813,7 +1926,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/30.png",
       "large": "https://images.pokemontcg.io/sv5/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-31",
@@ -1874,7 +1991,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/31.png",
       "large": "https://images.pokemontcg.io/sv5/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-32",
@@ -1928,7 +2049,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/32.png",
       "large": "https://images.pokemontcg.io/sv5/32_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-33",
@@ -1994,7 +2119,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/33.png",
       "large": "https://images.pokemontcg.io/sv5/33_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-34",
@@ -2060,7 +2189,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/34.png",
       "large": "https://images.pokemontcg.io/sv5/34_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-35",
@@ -2123,7 +2255,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/35.png",
       "large": "https://images.pokemontcg.io/sv5/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-36",
@@ -2177,7 +2313,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/36.png",
       "large": "https://images.pokemontcg.io/sv5/36_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-37",
@@ -2240,7 +2380,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/37.png",
       "large": "https://images.pokemontcg.io/sv5/37_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-38",
@@ -2304,7 +2448,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/38.png",
       "large": "https://images.pokemontcg.io/sv5/38_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-39",
@@ -2357,7 +2504,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/39.png",
       "large": "https://images.pokemontcg.io/sv5/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-40",
@@ -2412,7 +2563,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/40.png",
       "large": "https://images.pokemontcg.io/sv5/40_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-41",
@@ -2473,7 +2628,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/41.png",
       "large": "https://images.pokemontcg.io/sv5/41_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv5-42",
@@ -2527,7 +2687,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/42.png",
       "large": "https://images.pokemontcg.io/sv5/42_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-43",
@@ -2590,7 +2754,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/43.png",
       "large": "https://images.pokemontcg.io/sv5/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-44",
@@ -2651,7 +2819,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/44.png",
       "large": "https://images.pokemontcg.io/sv5/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-45",
@@ -2705,7 +2877,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/45.png",
       "large": "https://images.pokemontcg.io/sv5/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-46",
@@ -2758,7 +2934,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/46.png",
       "large": "https://images.pokemontcg.io/sv5/46_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-47",
@@ -2818,7 +2998,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/47.png",
       "large": "https://images.pokemontcg.io/sv5/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-48",
@@ -2880,7 +3064,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/48.png",
       "large": "https://images.pokemontcg.io/sv5/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-49",
@@ -2943,7 +3131,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/49.png",
       "large": "https://images.pokemontcg.io/sv5/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-50",
@@ -3006,7 +3198,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/50.png",
       "large": "https://images.pokemontcg.io/sv5/50_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-51",
@@ -3059,7 +3254,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/51.png",
       "large": "https://images.pokemontcg.io/sv5/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-52",
@@ -3122,7 +3321,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/52.png",
       "large": "https://images.pokemontcg.io/sv5/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-53",
@@ -3187,7 +3390,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/53.png",
       "large": "https://images.pokemontcg.io/sv5/53_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-54",
@@ -3253,7 +3460,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/54.png",
       "large": "https://images.pokemontcg.io/sv5/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-55",
@@ -3309,7 +3520,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/55.png",
       "large": "https://images.pokemontcg.io/sv5/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-56",
@@ -3371,7 +3586,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/56.png",
       "large": "https://images.pokemontcg.io/sv5/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-57",
@@ -3432,7 +3651,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/57.png",
       "large": "https://images.pokemontcg.io/sv5/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-58",
@@ -3485,7 +3708,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/58.png",
       "large": "https://images.pokemontcg.io/sv5/58_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-59",
@@ -3536,7 +3763,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/59.png",
       "large": "https://images.pokemontcg.io/sv5/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-60",
@@ -3603,7 +3834,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/60.png",
       "large": "https://images.pokemontcg.io/sv5/60_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-61",
@@ -3668,7 +3902,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/61.png",
       "large": "https://images.pokemontcg.io/sv5/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-62",
@@ -3734,7 +3972,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/62.png",
       "large": "https://images.pokemontcg.io/sv5/62_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv5-63",
@@ -3799,7 +4042,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/63.png",
       "large": "https://images.pokemontcg.io/sv5/63_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-64",
@@ -3864,7 +4111,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/64.png",
       "large": "https://images.pokemontcg.io/sv5/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-65",
@@ -3927,7 +4178,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/65.png",
       "large": "https://images.pokemontcg.io/sv5/65_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-66",
@@ -3984,7 +4239,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/66.png",
       "large": "https://images.pokemontcg.io/sv5/66_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-67",
@@ -4050,7 +4309,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/67.png",
       "large": "https://images.pokemontcg.io/sv5/67_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-68",
@@ -4111,7 +4374,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/68.png",
       "large": "https://images.pokemontcg.io/sv5/68_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-69",
@@ -4181,7 +4448,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/69.png",
       "large": "https://images.pokemontcg.io/sv5/69_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-70",
@@ -4240,7 +4511,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/70.png",
       "large": "https://images.pokemontcg.io/sv5/70_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-71",
@@ -4301,7 +4576,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/71.png",
       "large": "https://images.pokemontcg.io/sv5/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-72",
@@ -4369,7 +4648,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/72.png",
       "large": "https://images.pokemontcg.io/sv5/72_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-73",
@@ -4428,7 +4711,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/73.png",
       "large": "https://images.pokemontcg.io/sv5/73_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-74",
@@ -4485,7 +4772,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/74.png",
       "large": "https://images.pokemontcg.io/sv5/74_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-75",
@@ -4538,7 +4829,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/75.png",
       "large": "https://images.pokemontcg.io/sv5/75_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-76",
@@ -4585,7 +4880,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/76.png",
       "large": "https://images.pokemontcg.io/sv5/76_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-77",
@@ -4652,7 +4951,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/77.png",
       "large": "https://images.pokemontcg.io/sv5/77_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv5-78",
@@ -4712,7 +5016,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/78.png",
       "large": "https://images.pokemontcg.io/sv5/78_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv5-79",
@@ -4775,7 +5084,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/79.png",
       "large": "https://images.pokemontcg.io/sv5/79_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv5-80",
@@ -4838,7 +5152,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/80.png",
       "large": "https://images.pokemontcg.io/sv5/80_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-81",
@@ -4905,7 +5223,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/81.png",
       "large": "https://images.pokemontcg.io/sv5/81_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo"
+    ]
   },
   {
     "id": "sv5-82",
@@ -4968,7 +5290,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/82.png",
       "large": "https://images.pokemontcg.io/sv5/82_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-83",
@@ -5030,7 +5356,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/83.png",
       "large": "https://images.pokemontcg.io/sv5/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-84",
@@ -5088,7 +5418,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/84.png",
       "large": "https://images.pokemontcg.io/sv5/84_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv5-85",
@@ -5149,7 +5484,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/85.png",
       "large": "https://images.pokemontcg.io/sv5/85_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-86",
@@ -5212,7 +5551,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/86.png",
       "large": "https://images.pokemontcg.io/sv5/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-87",
@@ -5278,7 +5621,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/87.png",
       "large": "https://images.pokemontcg.io/sv5/87_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-88",
@@ -5344,7 +5691,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/88.png",
       "large": "https://images.pokemontcg.io/sv5/88_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-89",
@@ -5397,7 +5748,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/89.png",
       "large": "https://images.pokemontcg.io/sv5/89_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-90",
@@ -5448,7 +5803,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/90.png",
       "large": "https://images.pokemontcg.io/sv5/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-91",
@@ -5513,7 +5872,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/91.png",
       "large": "https://images.pokemontcg.io/sv5/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-92",
@@ -5577,7 +5940,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/92.png",
       "large": "https://images.pokemontcg.io/sv5/92_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-93",
@@ -5642,7 +6009,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/93.png",
       "large": "https://images.pokemontcg.io/sv5/93_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-94",
@@ -5711,7 +6082,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/94.png",
       "large": "https://images.pokemontcg.io/sv5/94_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-95",
@@ -5777,7 +6152,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/95.png",
       "large": "https://images.pokemontcg.io/sv5/95_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-96",
@@ -5843,7 +6222,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/96.png",
       "large": "https://images.pokemontcg.io/sv5/96_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-97",
@@ -5909,7 +6292,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/97.png",
       "large": "https://images.pokemontcg.io/sv5/97_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-98",
@@ -5971,7 +6358,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/98.png",
       "large": "https://images.pokemontcg.io/sv5/98_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-99",
@@ -6036,7 +6427,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/99.png",
       "large": "https://images.pokemontcg.io/sv5/99_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-100",
@@ -6099,7 +6493,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/100.png",
       "large": "https://images.pokemontcg.io/sv5/100_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-101",
@@ -6161,7 +6559,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/101.png",
       "large": "https://images.pokemontcg.io/sv5/101_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-102",
@@ -6224,7 +6626,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/102.png",
       "large": "https://images.pokemontcg.io/sv5/102_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-103",
@@ -6279,7 +6685,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/103.png",
       "large": "https://images.pokemontcg.io/sv5/103_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-104",
@@ -6342,7 +6752,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/104.png",
       "large": "https://images.pokemontcg.io/sv5/104_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-105",
@@ -6396,7 +6809,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/105.png",
       "large": "https://images.pokemontcg.io/sv5/105_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-106",
@@ -6460,7 +6877,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/106.png",
       "large": "https://images.pokemontcg.io/sv5/106_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-107",
@@ -6520,7 +6941,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/107.png",
       "large": "https://images.pokemontcg.io/sv5/107_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-108",
@@ -6587,7 +7012,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/108.png",
       "large": "https://images.pokemontcg.io/sv5/108_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-109",
@@ -6652,7 +7080,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/109.png",
       "large": "https://images.pokemontcg.io/sv5/109_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-110",
@@ -6722,7 +7154,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/110.png",
       "large": "https://images.pokemontcg.io/sv5/110_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-111",
@@ -6794,7 +7230,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/111.png",
       "large": "https://images.pokemontcg.io/sv5/111_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-112",
@@ -6862,7 +7301,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/112.png",
       "large": "https://images.pokemontcg.io/sv5/112_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-113",
@@ -6932,7 +7375,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/113.png",
       "large": "https://images.pokemontcg.io/sv5/113_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-114",
@@ -7002,7 +7449,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/114.png",
       "large": "https://images.pokemontcg.io/sv5/114_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-115",
@@ -7073,7 +7524,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/115.png",
       "large": "https://images.pokemontcg.io/sv5/115_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-116",
@@ -7135,7 +7590,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/116.png",
       "large": "https://images.pokemontcg.io/sv5/116_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-117",
@@ -7210,7 +7669,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/117.png",
       "large": "https://images.pokemontcg.io/sv5/117_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-118",
@@ -7276,7 +7739,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/118.png",
       "large": "https://images.pokemontcg.io/sv5/118_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-119",
@@ -7334,7 +7801,15 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/119.png",
       "large": "https://images.pokemontcg.io/sv5/119_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "EB Games",
+      "GameStop",
+      "Normal",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv5-120",
@@ -7395,7 +7870,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/120.png",
       "large": "https://images.pokemontcg.io/sv5/120_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-121",
@@ -7452,7 +7930,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/121.png",
       "large": "https://images.pokemontcg.io/sv5/121_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv5-122",
@@ -7512,7 +7996,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/122.png",
       "large": "https://images.pokemontcg.io/sv5/122_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-123",
@@ -7569,7 +8056,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/123.png",
       "large": "https://images.pokemontcg.io/sv5/123_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Jumbo"
+    ]
   },
   {
     "id": "sv5-124",
@@ -7635,7 +8126,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/124.png",
       "large": "https://images.pokemontcg.io/sv5/124_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-125",
@@ -7702,7 +8197,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/125.png",
       "large": "https://images.pokemontcg.io/sv5/125_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-126",
@@ -7762,7 +8261,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/126.png",
       "large": "https://images.pokemontcg.io/sv5/126_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-127",
@@ -7820,7 +8323,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/127.png",
       "large": "https://images.pokemontcg.io/sv5/127_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-128",
@@ -7876,7 +8383,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/128.png",
       "large": "https://images.pokemontcg.io/sv5/128_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-129",
@@ -7938,7 +8449,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/129.png",
       "large": "https://images.pokemontcg.io/sv5/129_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-130",
@@ -8001,7 +8516,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/130.png",
       "large": "https://images.pokemontcg.io/sv5/130_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-131",
@@ -8063,7 +8582,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/131.png",
       "large": "https://images.pokemontcg.io/sv5/131_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-132",
@@ -8128,7 +8651,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/132.png",
       "large": "https://images.pokemontcg.io/sv5/132_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-133",
@@ -8194,7 +8721,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/133.png",
       "large": "https://images.pokemontcg.io/sv5/133_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-134",
@@ -8260,7 +8791,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/134.png",
       "large": "https://images.pokemontcg.io/sv5/134_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-135",
@@ -8325,7 +8860,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/135.png",
       "large": "https://images.pokemontcg.io/sv5/135_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-136",
@@ -8388,7 +8927,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/136.png",
       "large": "https://images.pokemontcg.io/sv5/136_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-137",
@@ -8449,7 +8992,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/137.png",
       "large": "https://images.pokemontcg.io/sv5/137_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-138",
@@ -8511,7 +9058,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/138.png",
       "large": "https://images.pokemontcg.io/sv5/138_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-139",
@@ -8578,7 +9129,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/139.png",
       "large": "https://images.pokemontcg.io/sv5/139_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-140",
@@ -8604,7 +9159,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/140.png",
       "large": "https://images.pokemontcg.io/sv5/140_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-141",
@@ -8632,7 +9191,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/141.png",
       "large": "https://images.pokemontcg.io/sv5/141_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-142",
@@ -8657,7 +9219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/142.png",
       "large": "https://images.pokemontcg.io/sv5/142_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-143",
@@ -8682,7 +9248,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/143.png",
       "large": "https://images.pokemontcg.io/sv5/143_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-144",
@@ -8707,7 +9277,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/144.png",
       "large": "https://images.pokemontcg.io/sv5/144_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Play! Pokémon"
+    ]
   },
   {
     "id": "sv5-145",
@@ -8733,7 +9308,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/145.png",
       "large": "https://images.pokemontcg.io/sv5/145_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-146",
@@ -8758,7 +9337,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/146.png",
       "large": "https://images.pokemontcg.io/sv5/146_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-147",
@@ -8784,7 +9367,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/147.png",
       "large": "https://images.pokemontcg.io/sv5/147_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Regional Championship",
+      "Regional Championship (Staff)"
+    ]
   },
   {
     "id": "sv5-148",
@@ -8809,7 +9398,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/148.png",
       "large": "https://images.pokemontcg.io/sv5/148_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-149",
@@ -8835,7 +9428,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/149.png",
       "large": "https://images.pokemontcg.io/sv5/149_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-150",
@@ -8860,7 +9457,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/150.png",
       "large": "https://images.pokemontcg.io/sv5/150_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-151",
@@ -8885,7 +9486,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/151.png",
       "large": "https://images.pokemontcg.io/sv5/151_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-152",
@@ -8912,7 +9517,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/152.png",
       "large": "https://images.pokemontcg.io/sv5/152_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-153",
@@ -8939,7 +9547,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/153.png",
       "large": "https://images.pokemontcg.io/sv5/153_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-154",
@@ -8966,7 +9577,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/154.png",
       "large": "https://images.pokemontcg.io/sv5/154_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-155",
@@ -8991,7 +9605,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/155.png",
       "large": "https://images.pokemontcg.io/sv5/155_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-156",
@@ -9017,7 +9635,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/156.png",
       "large": "https://images.pokemontcg.io/sv5/156_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-157",
@@ -9044,7 +9666,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/157.png",
       "large": "https://images.pokemontcg.io/sv5/157_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-158",
@@ -9072,7 +9697,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/158.png",
       "large": "https://images.pokemontcg.io/sv5/158_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-159",
@@ -9097,7 +9725,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/159.png",
       "large": "https://images.pokemontcg.io/sv5/159_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-160",
@@ -9122,7 +9754,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/160.png",
       "large": "https://images.pokemontcg.io/sv5/160_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-161",
@@ -9145,7 +9781,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/161.png",
       "large": "https://images.pokemontcg.io/sv5/161_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv5-162",
@@ -9171,7 +9811,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/162.png",
       "large": "https://images.pokemontcg.io/sv5/162_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-163",
@@ -9233,7 +9876,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/163.png",
       "large": "https://images.pokemontcg.io/sv5/163_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-164",
@@ -9301,7 +9947,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/164.png",
       "large": "https://images.pokemontcg.io/sv5/164_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-165",
@@ -9365,7 +10014,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/165.png",
       "large": "https://images.pokemontcg.io/sv5/165_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-166",
@@ -9426,7 +10078,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/166.png",
       "large": "https://images.pokemontcg.io/sv5/166_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-167",
@@ -9480,7 +10135,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/167.png",
       "large": "https://images.pokemontcg.io/sv5/167_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-168",
@@ -9534,7 +10192,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/168.png",
       "large": "https://images.pokemontcg.io/sv5/168_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-169",
@@ -9590,7 +10251,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/169.png",
       "large": "https://images.pokemontcg.io/sv5/169_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-170",
@@ -9651,7 +10315,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/170.png",
       "large": "https://images.pokemontcg.io/sv5/170_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-171",
@@ -9719,7 +10386,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/171.png",
       "large": "https://images.pokemontcg.io/sv5/171_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-172",
@@ -9772,7 +10442,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/172.png",
       "large": "https://images.pokemontcg.io/sv5/172_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-173",
@@ -9830,7 +10503,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/173.png",
       "large": "https://images.pokemontcg.io/sv5/173_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-174",
@@ -9893,7 +10569,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/174.png",
       "large": "https://images.pokemontcg.io/sv5/174_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-175",
@@ -9957,7 +10636,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/175.png",
       "large": "https://images.pokemontcg.io/sv5/175_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-176",
@@ -10019,7 +10701,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/176.png",
       "large": "https://images.pokemontcg.io/sv5/176_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-177",
@@ -10082,7 +10767,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/177.png",
       "large": "https://images.pokemontcg.io/sv5/177_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-178",
@@ -10153,7 +10841,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/178.png",
       "large": "https://images.pokemontcg.io/sv5/178_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-179",
@@ -10215,7 +10906,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/179.png",
       "large": "https://images.pokemontcg.io/sv5/179_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-180",
@@ -10281,7 +10975,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/180.png",
       "large": "https://images.pokemontcg.io/sv5/180_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-181",
@@ -10346,7 +11043,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/181.png",
       "large": "https://images.pokemontcg.io/sv5/181_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-182",
@@ -10409,7 +11109,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/182.png",
       "large": "https://images.pokemontcg.io/sv5/182_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-183",
@@ -10470,7 +11173,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/183.png",
       "large": "https://images.pokemontcg.io/sv5/183_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-184",
@@ -10532,7 +11238,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/184.png",
       "large": "https://images.pokemontcg.io/sv5/184_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-185",
@@ -10600,7 +11309,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/185.png",
       "large": "https://images.pokemontcg.io/sv5/185_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-186",
@@ -10663,7 +11375,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/186.png",
       "large": "https://images.pokemontcg.io/sv5/186_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-187",
@@ -10729,7 +11444,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/187.png",
       "large": "https://images.pokemontcg.io/sv5/187_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-188",
@@ -10793,7 +11511,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/188.png",
       "large": "https://images.pokemontcg.io/sv5/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-189",
@@ -10856,7 +11577,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/189.png",
       "large": "https://images.pokemontcg.io/sv5/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-190",
@@ -10923,7 +11647,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/190.png",
       "large": "https://images.pokemontcg.io/sv5/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-191",
@@ -10990,7 +11717,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/191.png",
       "large": "https://images.pokemontcg.io/sv5/191_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-192",
@@ -11055,7 +11785,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/192.png",
       "large": "https://images.pokemontcg.io/sv5/192_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-193",
@@ -11118,7 +11851,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/193.png",
       "large": "https://images.pokemontcg.io/sv5/193_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-194",
@@ -11185,7 +11921,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/194.png",
       "large": "https://images.pokemontcg.io/sv5/194_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-195",
@@ -11257,7 +11996,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/195.png",
       "large": "https://images.pokemontcg.io/sv5/195_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-196",
@@ -11314,7 +12056,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/196.png",
       "large": "https://images.pokemontcg.io/sv5/196_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-197",
@@ -11339,7 +12084,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/197.png",
       "large": "https://images.pokemontcg.io/sv5/197_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-198",
@@ -11365,7 +12113,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/198.png",
       "large": "https://images.pokemontcg.io/sv5/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-199",
@@ -11390,7 +12141,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/199.png",
       "large": "https://images.pokemontcg.io/sv5/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-200",
@@ -11416,7 +12170,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/200.png",
       "large": "https://images.pokemontcg.io/sv5/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-201",
@@ -11441,7 +12198,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/201.png",
       "large": "https://images.pokemontcg.io/sv5/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-202",
@@ -11466,7 +12226,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/202.png",
       "large": "https://images.pokemontcg.io/sv5/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-203",
@@ -11529,7 +12292,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/203.png",
       "large": "https://images.pokemontcg.io/sv5/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-204",
@@ -11593,7 +12359,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/204.png",
       "large": "https://images.pokemontcg.io/sv5/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-205",
@@ -11656,7 +12425,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/205.png",
       "large": "https://images.pokemontcg.io/sv5/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-206",
@@ -11723,7 +12495,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/206.png",
       "large": "https://images.pokemontcg.io/sv5/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-207",
@@ -11788,7 +12563,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/207.png",
       "large": "https://images.pokemontcg.io/sv5/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-208",
@@ -11845,7 +12623,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/208.png",
       "large": "https://images.pokemontcg.io/sv5/208_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-209",
@@ -11870,7 +12651,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/209.png",
       "large": "https://images.pokemontcg.io/sv5/209_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-210",
@@ -11895,7 +12679,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/210.png",
       "large": "https://images.pokemontcg.io/sv5/210_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-211",
@@ -11920,7 +12707,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/211.png",
       "large": "https://images.pokemontcg.io/sv5/211_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-212",
@@ -11945,7 +12735,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/212.png",
       "large": "https://images.pokemontcg.io/sv5/212_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-213",
@@ -12008,7 +12801,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/213.png",
       "large": "https://images.pokemontcg.io/sv5/213_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-214",
@@ -12072,7 +12868,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/214.png",
       "large": "https://images.pokemontcg.io/sv5/214_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-215",
@@ -12135,7 +12934,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/215.png",
       "large": "https://images.pokemontcg.io/sv5/215_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-216",
@@ -12202,7 +13004,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/216.png",
       "large": "https://images.pokemontcg.io/sv5/216_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-217",
@@ -12267,7 +13072,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/217.png",
       "large": "https://images.pokemontcg.io/sv5/217_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv5-218",
@@ -12324,6 +13132,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv5/218.png",
       "large": "https://images.pokemontcg.io/sv5/218_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv6.json
+++ b/cards/en/sv6.json
@@ -61,7 +61,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/1.png",
       "large": "https://images.pokemontcg.io/sv6/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-2",
@@ -124,7 +128,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/2.png",
       "large": "https://images.pokemontcg.io/sv6/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-3",
@@ -187,7 +195,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/3.png",
       "large": "https://images.pokemontcg.io/sv6/3_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-4",
@@ -240,7 +252,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/4.png",
       "large": "https://images.pokemontcg.io/sv6/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-5",
@@ -298,7 +314,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/5.png",
       "large": "https://images.pokemontcg.io/sv6/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-6",
@@ -351,7 +371,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/6.png",
       "large": "https://images.pokemontcg.io/sv6/6_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-7",
@@ -412,7 +436,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/7.png",
       "large": "https://images.pokemontcg.io/sv6/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-8",
@@ -477,7 +505,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/8.png",
       "large": "https://images.pokemontcg.io/sv6/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-9",
@@ -537,7 +569,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/9.png",
       "large": "https://images.pokemontcg.io/sv6/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-10",
@@ -597,7 +633,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/10.png",
       "large": "https://images.pokemontcg.io/sv6/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-11",
@@ -658,7 +698,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/11.png",
       "large": "https://images.pokemontcg.io/sv6/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-12",
@@ -713,7 +757,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/12.png",
       "large": "https://images.pokemontcg.io/sv6/12_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-13",
@@ -778,7 +826,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/13.png",
       "large": "https://images.pokemontcg.io/sv6/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-14",
@@ -841,7 +893,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/14.png",
       "large": "https://images.pokemontcg.io/sv6/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-15",
@@ -904,7 +960,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/15.png",
       "large": "https://images.pokemontcg.io/sv6/15_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-16",
@@ -968,7 +1028,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/16.png",
       "large": "https://images.pokemontcg.io/sv6/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-17",
@@ -1021,7 +1085,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/17.png",
       "large": "https://images.pokemontcg.io/sv6/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-18",
@@ -1077,7 +1145,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/18.png",
       "large": "https://images.pokemontcg.io/sv6/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-19",
@@ -1139,7 +1211,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/19.png",
       "large": "https://images.pokemontcg.io/sv6/19_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-20",
@@ -1193,7 +1269,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/20.png",
       "large": "https://images.pokemontcg.io/sv6/20_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-21",
@@ -1249,7 +1329,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/21.png",
       "large": "https://images.pokemontcg.io/sv6/21_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-22",
@@ -1306,7 +1390,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/22.png",
       "large": "https://images.pokemontcg.io/sv6/22_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Set Stamp"
+    ]
   },
   {
     "id": "sv6-23",
@@ -1367,7 +1456,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/23.png",
       "large": "https://images.pokemontcg.io/sv6/23_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-24",
@@ -1424,7 +1516,13 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/24.png",
       "large": "https://images.pokemontcg.io/sv6/24_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "EB Games",
+      "GameStop"
+    ]
   },
   {
     "id": "sv6-25",
@@ -1486,7 +1584,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/25.png",
       "large": "https://images.pokemontcg.io/sv6/25_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-26",
@@ -1540,7 +1641,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/26.png",
       "large": "https://images.pokemontcg.io/sv6/26_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-27",
@@ -1593,7 +1698,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/27.png",
       "large": "https://images.pokemontcg.io/sv6/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-28",
@@ -1649,7 +1758,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/28.png",
       "large": "https://images.pokemontcg.io/sv6/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-29",
@@ -1720,7 +1833,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/29.png",
       "large": "https://images.pokemontcg.io/sv6/29_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-30",
@@ -1784,7 +1900,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/30.png",
       "large": "https://images.pokemontcg.io/sv6/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-31",
@@ -1838,7 +1958,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/31.png",
       "large": "https://images.pokemontcg.io/sv6/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-32",
@@ -1904,7 +2028,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/32.png",
       "large": "https://images.pokemontcg.io/sv6/32_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-33",
@@ -1964,7 +2092,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/33.png",
       "large": "https://images.pokemontcg.io/sv6/33_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv6-34",
@@ -2028,7 +2161,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/34.png",
       "large": "https://images.pokemontcg.io/sv6/34_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-35",
@@ -2093,7 +2230,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/35.png",
       "large": "https://images.pokemontcg.io/sv6/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-36",
@@ -2156,7 +2297,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/36.png",
       "large": "https://images.pokemontcg.io/sv6/36_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-37",
@@ -2220,7 +2365,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/37.png",
       "large": "https://images.pokemontcg.io/sv6/37_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-38",
@@ -2279,7 +2428,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/38.png",
       "large": "https://images.pokemontcg.io/sv6/38_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-39",
@@ -2339,7 +2492,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/39.png",
       "large": "https://images.pokemontcg.io/sv6/39_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-40",
@@ -2405,7 +2562,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/40.png",
       "large": "https://images.pokemontcg.io/sv6/40_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-41",
@@ -2468,7 +2628,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/41.png",
       "large": "https://images.pokemontcg.io/sv6/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-42",
@@ -2534,7 +2698,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/42.png",
       "large": "https://images.pokemontcg.io/sv6/42_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-43",
@@ -2597,7 +2765,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/43.png",
       "large": "https://images.pokemontcg.io/sv6/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-44",
@@ -2658,7 +2830,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/44.png",
       "large": "https://images.pokemontcg.io/sv6/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-45",
@@ -2720,7 +2896,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/45.png",
       "large": "https://images.pokemontcg.io/sv6/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-46",
@@ -2779,7 +2959,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/46.png",
       "large": "https://images.pokemontcg.io/sv6/46_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-47",
@@ -2835,7 +3019,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/47.png",
       "large": "https://images.pokemontcg.io/sv6/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-48",
@@ -2900,7 +3088,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/48.png",
       "large": "https://images.pokemontcg.io/sv6/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-49",
@@ -2953,7 +3145,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/49.png",
       "large": "https://images.pokemontcg.io/sv6/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-50",
@@ -3013,7 +3209,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/50.png",
       "large": "https://images.pokemontcg.io/sv6/50_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-51",
@@ -3068,7 +3268,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/51.png",
       "large": "https://images.pokemontcg.io/sv6/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-52",
@@ -3134,7 +3338,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/52.png",
       "large": "https://images.pokemontcg.io/sv6/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-53",
@@ -3193,7 +3401,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/53.png",
       "large": "https://images.pokemontcg.io/sv6/53_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv6-54",
@@ -3254,7 +3467,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/54.png",
       "large": "https://images.pokemontcg.io/sv6/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-55",
@@ -3313,7 +3530,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/55.png",
       "large": "https://images.pokemontcg.io/sv6/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-56",
@@ -3375,7 +3596,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/56.png",
       "large": "https://images.pokemontcg.io/sv6/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-57",
@@ -3429,7 +3654,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/57.png",
       "large": "https://images.pokemontcg.io/sv6/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-58",
@@ -3490,7 +3719,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/58.png",
       "large": "https://images.pokemontcg.io/sv6/58_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-59",
@@ -3540,7 +3773,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/59.png",
       "large": "https://images.pokemontcg.io/sv6/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv6-60",
@@ -3599,7 +3837,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/60.png",
       "large": "https://images.pokemontcg.io/sv6/60_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv6-61",
@@ -3661,7 +3904,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/61.png",
       "large": "https://images.pokemontcg.io/sv6/61_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-62",
@@ -3713,7 +3959,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/62.png",
       "large": "https://images.pokemontcg.io/sv6/62_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-63",
@@ -3775,7 +4025,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/63.png",
       "large": "https://images.pokemontcg.io/sv6/63_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-64",
@@ -3839,7 +4093,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/64.png",
       "large": "https://images.pokemontcg.io/sv6/64_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-65",
@@ -3907,7 +4164,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/65.png",
       "large": "https://images.pokemontcg.io/sv6/65_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-66",
@@ -3970,7 +4231,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/66.png",
       "large": "https://images.pokemontcg.io/sv6/66_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-67",
@@ -4025,7 +4290,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/67.png",
       "large": "https://images.pokemontcg.io/sv6/67_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-68",
@@ -4090,7 +4359,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/68.png",
       "large": "https://images.pokemontcg.io/sv6/68_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-69",
@@ -4136,7 +4408,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/69.png",
       "large": "https://images.pokemontcg.io/sv6/69_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-70",
@@ -4198,7 +4474,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/70.png",
       "large": "https://images.pokemontcg.io/sv6/70_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-71",
@@ -4249,7 +4529,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/71.png",
       "large": "https://images.pokemontcg.io/sv6/71_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-72",
@@ -4306,7 +4590,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/72.png",
       "large": "https://images.pokemontcg.io/sv6/72_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-73",
@@ -4366,7 +4654,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/73.png",
       "large": "https://images.pokemontcg.io/sv6/73_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-74",
@@ -4431,7 +4723,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/74.png",
       "large": "https://images.pokemontcg.io/sv6/74_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-75",
@@ -4487,7 +4783,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/75.png",
       "large": "https://images.pokemontcg.io/sv6/75_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-76",
@@ -4554,7 +4854,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/76.png",
       "large": "https://images.pokemontcg.io/sv6/76_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-77",
@@ -4620,7 +4924,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/77.png",
       "large": "https://images.pokemontcg.io/sv6/77_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-78",
@@ -4674,7 +4981,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/78.png",
       "large": "https://images.pokemontcg.io/sv6/78_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-79",
@@ -4738,7 +5049,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/79.png",
       "large": "https://images.pokemontcg.io/sv6/79_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-80",
@@ -4804,7 +5119,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/80.png",
       "large": "https://images.pokemontcg.io/sv6/80_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-81",
@@ -4864,7 +5183,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/81.png",
       "large": "https://images.pokemontcg.io/sv6/81_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-82",
@@ -4930,7 +5253,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/82.png",
       "large": "https://images.pokemontcg.io/sv6/82_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-83",
@@ -4986,7 +5313,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/83.png",
       "large": "https://images.pokemontcg.io/sv6/83_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-84",
@@ -5056,7 +5387,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/84.png",
       "large": "https://images.pokemontcg.io/sv6/84_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-85",
@@ -5122,7 +5457,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/85.png",
       "large": "https://images.pokemontcg.io/sv6/85_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-86",
@@ -5184,7 +5523,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/86.png",
       "large": "https://images.pokemontcg.io/sv6/86_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-87",
@@ -5248,7 +5591,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/87.png",
       "large": "https://images.pokemontcg.io/sv6/87_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-88",
@@ -5308,7 +5655,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/88.png",
       "large": "https://images.pokemontcg.io/sv6/88_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-89",
@@ -5368,7 +5719,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/89.png",
       "large": "https://images.pokemontcg.io/sv6/89_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-90",
@@ -5421,7 +5776,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/90.png",
       "large": "https://images.pokemontcg.io/sv6/90_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-91",
@@ -5493,7 +5852,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/91.png",
       "large": "https://images.pokemontcg.io/sv6/91_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-92",
@@ -5567,7 +5930,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/92.png",
       "large": "https://images.pokemontcg.io/sv6/92_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-93",
@@ -5628,7 +5995,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/93.png",
       "large": "https://images.pokemontcg.io/sv6/93_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-94",
@@ -5699,7 +6070,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/94.png",
       "large": "https://images.pokemontcg.io/sv6/94_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-95",
@@ -5760,7 +6134,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/95.png",
       "large": "https://images.pokemontcg.io/sv6/95_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv6-96",
@@ -5814,7 +6193,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/96.png",
       "large": "https://images.pokemontcg.io/sv6/96_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv6-97",
@@ -5877,7 +6261,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/97.png",
       "large": "https://images.pokemontcg.io/sv6/97_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-98",
@@ -5938,7 +6326,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/98.png",
       "large": "https://images.pokemontcg.io/sv6/98_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-99",
@@ -6002,7 +6394,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/99.png",
       "large": "https://images.pokemontcg.io/sv6/99_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-100",
@@ -6065,7 +6461,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/100.png",
       "large": "https://images.pokemontcg.io/sv6/100_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-101",
@@ -6122,7 +6522,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/101.png",
       "large": "https://images.pokemontcg.io/sv6/101_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-102",
@@ -6189,7 +6593,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/102.png",
       "large": "https://images.pokemontcg.io/sv6/102_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-103",
@@ -6243,7 +6651,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/103.png",
       "large": "https://images.pokemontcg.io/sv6/103_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-104",
@@ -6309,7 +6721,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/104.png",
       "large": "https://images.pokemontcg.io/sv6/104_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-105",
@@ -6374,7 +6790,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/105.png",
       "large": "https://images.pokemontcg.io/sv6/105_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-106",
@@ -6442,7 +6862,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/106.png",
       "large": "https://images.pokemontcg.io/sv6/106_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-107",
@@ -6493,7 +6916,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/107.png",
       "large": "https://images.pokemontcg.io/sv6/107_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-108",
@@ -6543,7 +6970,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/108.png",
       "large": "https://images.pokemontcg.io/sv6/108_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-109",
@@ -6605,7 +7036,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/109.png",
       "large": "https://images.pokemontcg.io/sv6/109_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-110",
@@ -6668,7 +7103,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/110.png",
       "large": "https://images.pokemontcg.io/sv6/110_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-111",
@@ -6724,7 +7163,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/111.png",
       "large": "https://images.pokemontcg.io/sv6/111_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo",
+      "Normal"
+    ]
   },
   {
     "id": "sv6-112",
@@ -6786,7 +7230,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/112.png",
       "large": "https://images.pokemontcg.io/sv6/112_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-113",
@@ -6849,7 +7296,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/113.png",
       "large": "https://images.pokemontcg.io/sv6/113_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-114",
@@ -6910,7 +7361,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/114.png",
       "large": "https://images.pokemontcg.io/sv6/114_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-115",
@@ -6976,7 +7431,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/115.png",
       "large": "https://images.pokemontcg.io/sv6/115_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-116",
@@ -7043,7 +7502,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/116.png",
       "large": "https://images.pokemontcg.io/sv6/116_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-117",
@@ -7108,7 +7571,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/117.png",
       "large": "https://images.pokemontcg.io/sv6/117_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-118",
@@ -7172,7 +7639,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/118.png",
       "large": "https://images.pokemontcg.io/sv6/118_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-119",
@@ -7240,7 +7711,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/119.png",
       "large": "https://images.pokemontcg.io/sv6/119_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-120",
@@ -7300,7 +7775,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/120.png",
       "large": "https://images.pokemontcg.io/sv6/120_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-121",
@@ -7373,7 +7852,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/121.png",
       "large": "https://images.pokemontcg.io/sv6/121_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-122",
@@ -7443,7 +7926,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/122.png",
       "large": "https://images.pokemontcg.io/sv6/122_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-123",
@@ -7511,7 +7998,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/123.png",
       "large": "https://images.pokemontcg.io/sv6/123_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-124",
@@ -7579,7 +8070,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/124.png",
       "large": "https://images.pokemontcg.io/sv6/124_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-125",
@@ -7648,7 +8143,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/125.png",
       "large": "https://images.pokemontcg.io/sv6/125_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-126",
@@ -7705,7 +8204,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/126.png",
       "large": "https://images.pokemontcg.io/sv6/126_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-127",
@@ -7749,7 +8252,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/127.png",
       "large": "https://images.pokemontcg.io/sv6/127_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-128",
@@ -7806,7 +8313,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/128.png",
       "large": "https://images.pokemontcg.io/sv6/128_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-129",
@@ -7862,7 +8373,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/129.png",
       "large": "https://images.pokemontcg.io/sv6/129_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-130",
@@ -7923,7 +8438,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/130.png",
       "large": "https://images.pokemontcg.io/sv6/130_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-131",
@@ -7975,7 +8493,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/131.png",
       "large": "https://images.pokemontcg.io/sv6/131_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-132",
@@ -8041,7 +8563,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/132.png",
       "large": "https://images.pokemontcg.io/sv6/132_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-133",
@@ -8106,7 +8632,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/133.png",
       "large": "https://images.pokemontcg.io/sv6/133_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-134",
@@ -8172,7 +8702,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/134.png",
       "large": "https://images.pokemontcg.io/sv6/134_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-135",
@@ -8243,7 +8776,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/135.png",
       "large": "https://images.pokemontcg.io/sv6/135_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-136",
@@ -8309,7 +8846,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/136.png",
       "large": "https://images.pokemontcg.io/sv6/136_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-137",
@@ -8372,7 +8913,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/137.png",
       "large": "https://images.pokemontcg.io/sv6/137_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-138",
@@ -8432,7 +8977,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/138.png",
       "large": "https://images.pokemontcg.io/sv6/138_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-139",
@@ -8501,7 +9050,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/139.png",
       "large": "https://images.pokemontcg.io/sv6/139_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-140",
@@ -8568,7 +9121,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/140.png",
       "large": "https://images.pokemontcg.io/sv6/140_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-141",
@@ -8634,7 +9191,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/141.png",
       "large": "https://images.pokemontcg.io/sv6/141_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-142",
@@ -8659,7 +9219,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/142.png",
       "large": "https://images.pokemontcg.io/sv6/142_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-143",
@@ -8684,7 +9248,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/143.png",
       "large": "https://images.pokemontcg.io/sv6/143_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-144",
@@ -8709,7 +9277,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/144.png",
       "large": "https://images.pokemontcg.io/sv6/144_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-145",
@@ -8734,7 +9306,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/145.png",
       "large": "https://images.pokemontcg.io/sv6/145_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-146",
@@ -8760,7 +9336,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/146.png",
       "large": "https://images.pokemontcg.io/sv6/146_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Professor Program"
+    ]
   },
   {
     "id": "sv6-147",
@@ -8785,7 +9366,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/147.png",
       "large": "https://images.pokemontcg.io/sv6/147_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-148",
@@ -8810,7 +9395,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/148.png",
       "large": "https://images.pokemontcg.io/sv6/148_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-149",
@@ -8835,7 +9424,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/149.png",
       "large": "https://images.pokemontcg.io/sv6/149_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-150",
@@ -8861,7 +9454,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/150.png",
       "large": "https://images.pokemontcg.io/sv6/150_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-151",
@@ -8886,7 +9483,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/151.png",
       "large": "https://images.pokemontcg.io/sv6/151_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-152",
@@ -8914,7 +9515,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/152.png",
       "large": "https://images.pokemontcg.io/sv6/152_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-153",
@@ -8939,7 +9543,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/153.png",
       "large": "https://images.pokemontcg.io/sv6/153_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-154",
@@ -8964,7 +9572,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/154.png",
       "large": "https://images.pokemontcg.io/sv6/154_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-155",
@@ -8989,7 +9601,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/155.png",
       "large": "https://images.pokemontcg.io/sv6/155_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-156",
@@ -9014,7 +9630,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/156.png",
       "large": "https://images.pokemontcg.io/sv6/156_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-157",
@@ -9039,7 +9659,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/157.png",
       "large": "https://images.pokemontcg.io/sv6/157_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-158",
@@ -9065,7 +9689,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/158.png",
       "large": "https://images.pokemontcg.io/sv6/158_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-159",
@@ -9090,7 +9718,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/159.png",
       "large": "https://images.pokemontcg.io/sv6/159_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-160",
@@ -9115,7 +9747,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/160.png",
       "large": "https://images.pokemontcg.io/sv6/160_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-161",
@@ -9140,7 +9776,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/161.png",
       "large": "https://images.pokemontcg.io/sv6/161_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-162",
@@ -9168,7 +9808,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/162.png",
       "large": "https://images.pokemontcg.io/sv6/162_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-163",
@@ -9196,7 +9839,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/163.png",
       "large": "https://images.pokemontcg.io/sv6/163_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-164",
@@ -9225,7 +9871,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/164.png",
       "large": "https://images.pokemontcg.io/sv6/164_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-165",
@@ -9253,7 +9902,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/165.png",
       "large": "https://images.pokemontcg.io/sv6/165_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-166",
@@ -9276,7 +9928,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/166.png",
       "large": "https://images.pokemontcg.io/sv6/166_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6-167",
@@ -9302,7 +9958,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/167.png",
       "large": "https://images.pokemontcg.io/sv6/167_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-168",
@@ -9365,7 +10024,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/168.png",
       "large": "https://images.pokemontcg.io/sv6/168_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-169",
@@ -9426,7 +10088,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/169.png",
       "large": "https://images.pokemontcg.io/sv6/169_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-170",
@@ -9482,7 +10147,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/170.png",
       "large": "https://images.pokemontcg.io/sv6/170_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-171",
@@ -9536,7 +10204,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/171.png",
       "large": "https://images.pokemontcg.io/sv6/171_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-172",
@@ -9600,7 +10271,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/172.png",
       "large": "https://images.pokemontcg.io/sv6/172_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-173",
@@ -9660,7 +10334,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/173.png",
       "large": "https://images.pokemontcg.io/sv6/173_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-174",
@@ -9719,7 +10396,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/174.png",
       "large": "https://images.pokemontcg.io/sv6/174_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-175",
@@ -9778,7 +10458,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/175.png",
       "large": "https://images.pokemontcg.io/sv6/175_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-176",
@@ -9839,7 +10522,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/176.png",
       "large": "https://images.pokemontcg.io/sv6/176_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-177",
@@ -9890,7 +10576,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/177.png",
       "large": "https://images.pokemontcg.io/sv6/177_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-178",
@@ -9946,7 +10635,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/178.png",
       "large": "https://images.pokemontcg.io/sv6/178_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-179",
@@ -10012,7 +10704,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/179.png",
       "large": "https://images.pokemontcg.io/sv6/179_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-180",
@@ -10073,7 +10768,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/180.png",
       "large": "https://images.pokemontcg.io/sv6/180_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-181",
@@ -10137,7 +10835,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/181.png",
       "large": "https://images.pokemontcg.io/sv6/181_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-182",
@@ -10204,7 +10905,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/182.png",
       "large": "https://images.pokemontcg.io/sv6/182_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-183",
@@ -10258,7 +10962,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/183.png",
       "large": "https://images.pokemontcg.io/sv6/183_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-184",
@@ -10331,7 +11038,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/184.png",
       "large": "https://images.pokemontcg.io/sv6/184_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-185",
@@ -10388,7 +11098,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/185.png",
       "large": "https://images.pokemontcg.io/sv6/185_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-186",
@@ -10440,7 +11153,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/186.png",
       "large": "https://images.pokemontcg.io/sv6/186_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-187",
@@ -10505,7 +11221,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/187.png",
       "large": "https://images.pokemontcg.io/sv6/187_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-188",
@@ -10576,7 +11295,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/188.png",
       "large": "https://images.pokemontcg.io/sv6/188_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-189",
@@ -10637,7 +11359,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/189.png",
       "large": "https://images.pokemontcg.io/sv6/189_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-190",
@@ -10699,7 +11424,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/190.png",
       "large": "https://images.pokemontcg.io/sv6/190_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-191",
@@ -10770,7 +11498,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/191.png",
       "large": "https://images.pokemontcg.io/sv6/191_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-192",
@@ -10836,7 +11567,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/192.png",
       "large": "https://images.pokemontcg.io/sv6/192_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-193",
@@ -10898,7 +11632,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/193.png",
       "large": "https://images.pokemontcg.io/sv6/193_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-194",
@@ -10962,7 +11699,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/194.png",
       "large": "https://images.pokemontcg.io/sv6/194_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-195",
@@ -11027,7 +11767,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/195.png",
       "large": "https://images.pokemontcg.io/sv6/195_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-196",
@@ -11093,7 +11836,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/196.png",
       "large": "https://images.pokemontcg.io/sv6/196_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-197",
@@ -11164,7 +11910,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/197.png",
       "large": "https://images.pokemontcg.io/sv6/197_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-198",
@@ -11232,7 +11981,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/198.png",
       "large": "https://images.pokemontcg.io/sv6/198_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-199",
@@ -11294,7 +12046,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/199.png",
       "large": "https://images.pokemontcg.io/sv6/199_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-200",
@@ -11355,7 +12110,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/200.png",
       "large": "https://images.pokemontcg.io/sv6/200_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-201",
@@ -11421,7 +12179,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/201.png",
       "large": "https://images.pokemontcg.io/sv6/201_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-202",
@@ -11487,7 +12248,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/202.png",
       "large": "https://images.pokemontcg.io/sv6/202_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-203",
@@ -11512,7 +12276,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/203.png",
       "large": "https://images.pokemontcg.io/sv6/203_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-204",
@@ -11537,7 +12304,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/204.png",
       "large": "https://images.pokemontcg.io/sv6/204_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-205",
@@ -11562,7 +12332,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/205.png",
       "large": "https://images.pokemontcg.io/sv6/205_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-206",
@@ -11587,7 +12360,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/206.png",
       "large": "https://images.pokemontcg.io/sv6/206_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-207",
@@ -11612,7 +12388,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/207.png",
       "large": "https://images.pokemontcg.io/sv6/207_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-208",
@@ -11637,7 +12416,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/208.png",
       "large": "https://images.pokemontcg.io/sv6/208_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-209",
@@ -11662,7 +12444,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/209.png",
       "large": "https://images.pokemontcg.io/sv6/209_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-210",
@@ -11723,7 +12508,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/210.png",
       "large": "https://images.pokemontcg.io/sv6/210_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-211",
@@ -11785,7 +12573,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/211.png",
       "large": "https://images.pokemontcg.io/sv6/211_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-212",
@@ -11851,7 +12642,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/212.png",
       "large": "https://images.pokemontcg.io/sv6/212_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-213",
@@ -11915,7 +12709,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/213.png",
       "large": "https://images.pokemontcg.io/sv6/213_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-214",
@@ -11983,7 +12780,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/214.png",
       "large": "https://images.pokemontcg.io/sv6/214_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-215",
@@ -12045,7 +12845,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/215.png",
       "large": "https://images.pokemontcg.io/sv6/215_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-216",
@@ -12111,7 +12914,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/216.png",
       "large": "https://images.pokemontcg.io/sv6/216_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-217",
@@ -12136,7 +12942,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/217.png",
       "large": "https://images.pokemontcg.io/sv6/217_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-218",
@@ -12161,7 +12970,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/218.png",
       "large": "https://images.pokemontcg.io/sv6/218_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-219",
@@ -12186,7 +12998,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/219.png",
       "large": "https://images.pokemontcg.io/sv6/219_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-220",
@@ -12211,7 +13026,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/220.png",
       "large": "https://images.pokemontcg.io/sv6/220_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-221",
@@ -12273,7 +13091,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/221.png",
       "large": "https://images.pokemontcg.io/sv6/221_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-222",
@@ -12339,7 +13160,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/222.png",
       "large": "https://images.pokemontcg.io/sv6/222_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-223",
@@ -12364,7 +13188,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/223.png",
       "large": "https://images.pokemontcg.io/sv6/223_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-224",
@@ -12389,7 +13216,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/224.png",
       "large": "https://images.pokemontcg.io/sv6/224_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-225",
@@ -12415,7 +13245,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/225.png",
       "large": "https://images.pokemontcg.io/sv6/225_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6-226",
@@ -12438,6 +13271,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6/226.png",
       "large": "https://images.pokemontcg.io/sv6/226_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]

--- a/cards/en/sv6pt5.json
+++ b/cards/en/sv6pt5.json
@@ -48,7 +48,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/1.png",
       "large": "https://images.pokemontcg.io/sv6pt5/1_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-2",
@@ -105,7 +109,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/2.png",
       "large": "https://images.pokemontcg.io/sv6pt5/2_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-3",
@@ -165,7 +173,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/3.png",
       "large": "https://images.pokemontcg.io/sv6pt5/3_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-4",
@@ -226,7 +238,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/4.png",
       "large": "https://images.pokemontcg.io/sv6pt5/4_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-5",
@@ -285,7 +301,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/5.png",
       "large": "https://images.pokemontcg.io/sv6pt5/5_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-6",
@@ -335,7 +355,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/6.png",
       "large": "https://images.pokemontcg.io/sv6pt5/6_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-7",
@@ -398,7 +422,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/7.png",
       "large": "https://images.pokemontcg.io/sv6pt5/7_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-8",
@@ -460,7 +488,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/8.png",
       "large": "https://images.pokemontcg.io/sv6pt5/8_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-9",
@@ -519,7 +551,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/9.png",
       "large": "https://images.pokemontcg.io/sv6pt5/9_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-10",
@@ -580,7 +616,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/10.png",
       "large": "https://images.pokemontcg.io/sv6pt5/10_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv6pt5-11",
@@ -642,7 +683,12 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/11.png",
       "large": "https://images.pokemontcg.io/sv6pt5/11_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo",
+      "Cosmos Holo"
+    ]
   },
   {
     "id": "sv6pt5-12",
@@ -705,7 +751,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/12.png",
       "large": "https://images.pokemontcg.io/sv6pt5/12_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-13",
@@ -766,7 +815,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/13.png",
       "large": "https://images.pokemontcg.io/sv6pt5/13_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-14",
@@ -825,7 +878,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/14.png",
       "large": "https://images.pokemontcg.io/sv6pt5/14_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-15",
@@ -891,7 +948,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/15.png",
       "large": "https://images.pokemontcg.io/sv6pt5/15_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-16",
@@ -949,7 +1009,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/16.png",
       "large": "https://images.pokemontcg.io/sv6pt5/16_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-17",
@@ -1006,7 +1070,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/17.png",
       "large": "https://images.pokemontcg.io/sv6pt5/17_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-18",
@@ -1073,7 +1141,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/18.png",
       "large": "https://images.pokemontcg.io/sv6pt5/18_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-19",
@@ -1140,7 +1212,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/19.png",
       "large": "https://images.pokemontcg.io/sv6pt5/19_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-20",
@@ -1206,7 +1282,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/20.png",
       "large": "https://images.pokemontcg.io/sv6pt5/20_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-21",
@@ -1271,7 +1351,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/21.png",
       "large": "https://images.pokemontcg.io/sv6pt5/21_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-22",
@@ -1331,7 +1415,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/22.png",
       "large": "https://images.pokemontcg.io/sv6pt5/22_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-23",
@@ -1392,7 +1480,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/23.png",
       "large": "https://images.pokemontcg.io/sv6pt5/23_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-24",
@@ -1453,7 +1545,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/24.png",
       "large": "https://images.pokemontcg.io/sv6pt5/24_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-25",
@@ -1513,7 +1609,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/25.png",
       "large": "https://images.pokemontcg.io/sv6pt5/25_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-26",
@@ -1573,7 +1673,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/26.png",
       "large": "https://images.pokemontcg.io/sv6pt5/26_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-27",
@@ -1639,7 +1743,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/27.png",
       "large": "https://images.pokemontcg.io/sv6pt5/27_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-28",
@@ -1707,7 +1815,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/28.png",
       "large": "https://images.pokemontcg.io/sv6pt5/28_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-29",
@@ -1766,7 +1878,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/29.png",
       "large": "https://images.pokemontcg.io/sv6pt5/29_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-30",
@@ -1814,7 +1930,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/30.png",
       "large": "https://images.pokemontcg.io/sv6pt5/30_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-31",
@@ -1875,7 +1995,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/31.png",
       "large": "https://images.pokemontcg.io/sv6pt5/31_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-32",
@@ -1936,7 +2060,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/32.png",
       "large": "https://images.pokemontcg.io/sv6pt5/32_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-33",
@@ -1996,7 +2124,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/33.png",
       "large": "https://images.pokemontcg.io/sv6pt5/33_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-34",
@@ -2058,7 +2190,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/34.png",
       "large": "https://images.pokemontcg.io/sv6pt5/34_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-35",
@@ -2123,7 +2259,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/35.png",
       "large": "https://images.pokemontcg.io/sv6pt5/35_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-36",
@@ -2185,7 +2325,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/36.png",
       "large": "https://images.pokemontcg.io/sv6pt5/36_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-37",
@@ -2243,7 +2386,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/37.png",
       "large": "https://images.pokemontcg.io/sv6pt5/37_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-38",
@@ -2301,7 +2447,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/38.png",
       "large": "https://images.pokemontcg.io/sv6pt5/38_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-39",
@@ -2358,7 +2507,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/39.png",
       "large": "https://images.pokemontcg.io/sv6pt5/39_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-40",
@@ -2421,7 +2573,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/40.png",
       "large": "https://images.pokemontcg.io/sv6pt5/40_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-41",
@@ -2492,7 +2648,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/41.png",
       "large": "https://images.pokemontcg.io/sv6pt5/41_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-42",
@@ -2560,7 +2720,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/42.png",
       "large": "https://images.pokemontcg.io/sv6pt5/42_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-43",
@@ -2624,7 +2788,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/43.png",
       "large": "https://images.pokemontcg.io/sv6pt5/43_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-44",
@@ -2680,7 +2848,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/44.png",
       "large": "https://images.pokemontcg.io/sv6pt5/44_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-45",
@@ -2735,7 +2907,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/45.png",
       "large": "https://images.pokemontcg.io/sv6pt5/45_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-46",
@@ -2789,7 +2965,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/46.png",
       "large": "https://images.pokemontcg.io/sv6pt5/46_hires.png"
-    }
+    },
+    "variants": [
+      "Holo",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-47",
@@ -2843,7 +3023,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/47.png",
       "large": "https://images.pokemontcg.io/sv6pt5/47_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-48",
@@ -2895,7 +3079,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/48.png",
       "large": "https://images.pokemontcg.io/sv6pt5/48_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-49",
@@ -2956,7 +3144,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/49.png",
       "large": "https://images.pokemontcg.io/sv6pt5/49_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-50",
@@ -3024,7 +3216,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/50.png",
       "large": "https://images.pokemontcg.io/sv6pt5/50_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-51",
@@ -3072,7 +3268,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/51.png",
       "large": "https://images.pokemontcg.io/sv6pt5/51_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-52",
@@ -3124,7 +3324,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/52.png",
       "large": "https://images.pokemontcg.io/sv6pt5/52_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-53",
@@ -3186,7 +3390,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/53.png",
       "large": "https://images.pokemontcg.io/sv6pt5/53_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-54",
@@ -3210,7 +3418,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/54.png",
       "large": "https://images.pokemontcg.io/sv6pt5/54_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-55",
@@ -3234,7 +3446,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/55.png",
       "large": "https://images.pokemontcg.io/sv6pt5/55_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-56",
@@ -3258,7 +3474,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/56.png",
       "large": "https://images.pokemontcg.io/sv6pt5/56_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-57",
@@ -3282,7 +3502,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/57.png",
       "large": "https://images.pokemontcg.io/sv6pt5/57_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-58",
@@ -3308,7 +3532,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/58.png",
       "large": "https://images.pokemontcg.io/sv6pt5/58_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-59",
@@ -3332,7 +3559,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/59.png",
       "large": "https://images.pokemontcg.io/sv6pt5/59_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-60",
@@ -3358,7 +3589,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/60.png",
       "large": "https://images.pokemontcg.io/sv6pt5/60_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-61",
@@ -3382,7 +3616,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/61.png",
       "large": "https://images.pokemontcg.io/sv6pt5/61_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-62",
@@ -3408,7 +3646,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/62.png",
       "large": "https://images.pokemontcg.io/sv6pt5/62_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-63",
@@ -3432,7 +3673,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/63.png",
       "large": "https://images.pokemontcg.io/sv6pt5/63_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-64",
@@ -3456,7 +3701,11 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/64.png",
       "large": "https://images.pokemontcg.io/sv6pt5/64_hires.png"
-    }
+    },
+    "variants": [
+      "Normal",
+      "Reverse Holo"
+    ]
   },
   {
     "id": "sv6pt5-65",
@@ -3506,7 +3755,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/65.png",
       "large": "https://images.pokemontcg.io/sv6pt5/65_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-66",
@@ -3568,7 +3820,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/66.png",
       "large": "https://images.pokemontcg.io/sv6pt5/66_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-67",
@@ -3629,7 +3884,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/67.png",
       "large": "https://images.pokemontcg.io/sv6pt5/67_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-68",
@@ -3696,7 +3954,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/68.png",
       "large": "https://images.pokemontcg.io/sv6pt5/68_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-69",
@@ -3763,7 +4024,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/69.png",
       "large": "https://images.pokemontcg.io/sv6pt5/69_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-70",
@@ -3829,7 +4093,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/70.png",
       "large": "https://images.pokemontcg.io/sv6pt5/70_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-71",
@@ -3894,7 +4161,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/71.png",
       "large": "https://images.pokemontcg.io/sv6pt5/71_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-72",
@@ -3953,7 +4223,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/72.png",
       "large": "https://images.pokemontcg.io/sv6pt5/72_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-73",
@@ -4005,7 +4278,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/73.png",
       "large": "https://images.pokemontcg.io/sv6pt5/73_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-74",
@@ -4059,7 +4335,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/74.png",
       "large": "https://images.pokemontcg.io/sv6pt5/74_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-75",
@@ -4120,7 +4399,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/75.png",
       "large": "https://images.pokemontcg.io/sv6pt5/75_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-76",
@@ -4191,7 +4473,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/76.png",
       "large": "https://images.pokemontcg.io/sv6pt5/76_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-77",
@@ -4246,7 +4531,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/77.png",
       "large": "https://images.pokemontcg.io/sv6pt5/77_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-78",
@@ -4307,7 +4595,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/78.png",
       "large": "https://images.pokemontcg.io/sv6pt5/78_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-79",
@@ -4369,7 +4660,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/79.png",
       "large": "https://images.pokemontcg.io/sv6pt5/79_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-80",
@@ -4432,7 +4726,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/80.png",
       "large": "https://images.pokemontcg.io/sv6pt5/80_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-81",
@@ -4498,7 +4795,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/81.png",
       "large": "https://images.pokemontcg.io/sv6pt5/81_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-82",
@@ -4560,7 +4860,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/82.png",
       "large": "https://images.pokemontcg.io/sv6pt5/82_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-83",
@@ -4618,7 +4921,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/83.png",
       "large": "https://images.pokemontcg.io/sv6pt5/83_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-84",
@@ -4676,7 +4982,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/84.png",
       "large": "https://images.pokemontcg.io/sv6pt5/84_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-85",
@@ -4733,7 +5042,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/85.png",
       "large": "https://images.pokemontcg.io/sv6pt5/85_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-86",
@@ -4757,7 +5069,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/86.png",
       "large": "https://images.pokemontcg.io/sv6pt5/86_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-87",
@@ -4781,7 +5096,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/87.png",
       "large": "https://images.pokemontcg.io/sv6pt5/87_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-88",
@@ -4805,7 +5123,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/88.png",
       "large": "https://images.pokemontcg.io/sv6pt5/88_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-89",
@@ -4829,7 +5150,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/89.png",
       "large": "https://images.pokemontcg.io/sv6pt5/89_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-90",
@@ -4891,7 +5215,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/90.png",
       "large": "https://images.pokemontcg.io/sv6pt5/90_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-91",
@@ -4949,7 +5276,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/91.png",
       "large": "https://images.pokemontcg.io/sv6pt5/91_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-92",
@@ -5007,7 +5337,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/92.png",
       "large": "https://images.pokemontcg.io/sv6pt5/92_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-93",
@@ -5064,7 +5397,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/93.png",
       "large": "https://images.pokemontcg.io/sv6pt5/93_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-94",
@@ -5088,7 +5424,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/94.png",
       "large": "https://images.pokemontcg.io/sv6pt5/94_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-95",
@@ -5145,7 +5484,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/95.png",
       "large": "https://images.pokemontcg.io/sv6pt5/95_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-96",
@@ -5170,7 +5512,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/96.png",
       "large": "https://images.pokemontcg.io/sv6pt5/96_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-97",
@@ -5194,7 +5539,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/97.png",
       "large": "https://images.pokemontcg.io/sv6pt5/97_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-98",
@@ -5216,7 +5564,10 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/98.png",
       "large": "https://images.pokemontcg.io/sv6pt5/98_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   },
   {
     "id": "sv6pt5-99",
@@ -5238,6 +5589,9 @@
     "images": {
       "small": "https://images.pokemontcg.io/sv6pt5/99.png",
       "large": "https://images.pokemontcg.io/sv6pt5/99_hires.png"
-    }
+    },
+    "variants": [
+      "Holo"
+    ]
   }
 ]


### PR DESCRIPTION
Partially resolves https://github.com/PokemonTCG/pokemon-tcg-data/issues/276 by adding card variants for just the SV sets. I scraped the variant names from https://dextcg.com/.