### PR TITLE
Added standard legality to reprinted cards

### DIFF
--- a/cards/en/bw10.json
+++ b/cards/en/bw10.json
@@ -5164,6 +5164,7 @@
     "rarity": "Rare ACE",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bw5.json
+++ b/cards/en/bw5.json
@@ -5658,6 +5658,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/bwp.json
+++ b/cards/en/bwp.json
@@ -5511,6 +5511,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm1.json
+++ b/cards/en/sm1.json
@@ -7335,6 +7335,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7617,6 +7618,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm2.json
+++ b/cards/en/sm2.json
@@ -7673,6 +7673,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7696,6 +7697,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10105,6 +10107,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm35.json
+++ b/cards/en/sm35.json
@@ -3844,6 +3844,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sm4.json
+++ b/cards/en/sm4.json
@@ -5744,6 +5744,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -7302,6 +7303,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/sma.json
+++ b/cards/en/sma.json
@@ -5500,6 +5500,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/smp.json
+++ b/cards/en/smp.json
@@ -5126,6 +5126,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -9948,6 +9949,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -15371,6 +15373,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/swsh11tg.json
+++ b/cards/en/swsh11tg.json
@@ -1422,6 +1422,7 @@
     "rarity": "Rare Ultra",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "regulationMark": "E",

--- a/cards/en/swsh8.json
+++ b/cards/en/swsh8.json
@@ -13525,6 +13525,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "regulationMark": "E",

--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -5814,6 +5814,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy5.json
+++ b/cards/en/xy5.json
@@ -7600,6 +7600,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -8896,6 +8897,7 @@
     "rarity": "Rare Secret",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xy7.json
+++ b/cards/en/xy7.json
@@ -4443,6 +4443,7 @@
     "rarity": "Uncommon",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {

--- a/cards/en/xyp.json
+++ b/cards/en/xyp.json
@@ -1697,6 +1697,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -5804,6 +5805,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {
@@ -10883,6 +10885,7 @@
     "rarity": "Promo",
     "legalities": {
       "unlimited": "Legal",
+      "standard": "Legal",
       "expanded": "Legal"
     },
     "images": {


### PR DESCRIPTION
The impacted cards are:
```
Champions Festival bwp-BW95
Enhanced Hammer bw5-94
Scoop Up Cyclone bw10-95
Champions Festival xyp-XY27
Champions Festival xyp-XY91
Champions Festival xyp-XY176
Enhanced Hammer xy4-94
Fresh Water Set xy5-129
Enhanced Hammer xy5-162
Lucky Helmet xy7-77
Nest Ball sm1-123
Ultra Ball sm1-135
Champions Festival smp-SM78
Champions Festival smp-SM148
Champions Festival smp-SM231
Enhanced Hammer sm2-124
Enhanced Hammer sm2-124a
Enhanced Hammer sm2-162
Ultra Ball sm35-68a
Counter Catcher sm4-91
Counter Catcher sm4-120
Lady sma-SV86
Cook swsh8-228
Cook swsh11tg-TG25
```