### PR TITLE
Fixed HP of bp-2

### DIFF
--- a/cards/en/bp.json
+++ b/cards/en/bp.json
@@ -69,7 +69,7 @@
       "Basic"
     ],
     "level": "33",
-    "hp": "70",
+    "hp": "60",
     "types": [
       "Fighting"
     ],


### PR DESCRIPTION
Wizards decided to nerf this card (to spite Nintendo, according to the rumors)