### PR TITLE
Fixing typos in reprinted cards

### DIFF
--- a/cards/en/col1.json
+++ b/cards/en/col1.json
@@ -20,7 +20,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "",
-        "text": "Return 1 of your Pokémon and all cards attached to it in your hand."
+        "text": "Return 1 of your Pokémon and all cards attached to it to your hand."
       },
       {
         "name": "Moon Impact",
@@ -1271,7 +1271,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "30",
-        "text": "During your opponent's next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent's Pokémon than has any Poké-Powers or Poké-Bodies."
+        "text": "During your opponent's next turn, prevent all effects, including damage, done to Umbreon by attacks from your opponent's Pokémon that has any Poké-Powers or Poké-Bodies."
       },
       {
         "name": "Quick Blow",

--- a/cards/en/hgss3.json
+++ b/cards/en/hgss3.json
@@ -595,7 +595,7 @@
         ],
         "convertedEnergyCost": 2,
         "damage": "30+",
-        "text": "Flip a coin. If heads, this attack does 30 damage plus 30 damage."
+        "text": "Flip a coin. If heads, this attack does 30 damage plus 30 more damage."
       }
     ],
     "weaknesses": [
@@ -3120,7 +3120,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Flip a coin. If heads, prevent all effects of attack, including damage, done to Hitmonchan during your opponent's next turn."
+        "text": "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent's next turn."
       },
       {
         "name": "Sky Uppercut",

--- a/cards/en/xy4.json
+++ b/cards/en/xy4.json
@@ -4754,7 +4754,7 @@
         ],
         "convertedEnergyCost": 1,
         "damage": "",
-        "text": "Heal 10 damage from this Pokémon"
+        "text": "Heal 10 damage from this Pokémon."
       },
       {
         "name": "Tackle",


### PR DESCRIPTION
I've made a script that looks for cards with the `Pokémon` supertype that are almost identical to each other, and I've found several groups of cards that only differ because of typos. I'm gonna be fixing those typos when I have time. I'm opening this PR as a draft, I'll mark it as ready for review when I think I'm done.